### PR TITLE
Feature import permissions entitlements and product revoke script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,37 +29,39 @@
 
 _HelloID-Conn-Prov-Target-HelloID_ is a _target_ connector. _HelloID_ provides a set of REST API's that allow you to programmatically interact with its data. The HelloID connector uses the API endpoints listed in the table below.
 
-| Endpoint                                                                                                                    | Description                         |
-| --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| [/api/v1/users/{UserId}](https://apidocs.helloid.com/docs/helloid/562f51f234ff9-get-a-user)                                 | Get specific user account (GET)     |
-| [/api/v1/users/](https://apidocs.helloid.com/docs/helloid/7d9592b2cfeed-add-a-user)                                         | Create user accounts (POST)         |
-| [/api/v1/users/{UserId}](https://apidocs.helloid.com/docs/helloid/b432862fd92c6-update-a-user)                              | Update user accounts (PUT)          |
-| [/api/v1/users/{UserId}](https://apidocs.helloid.com/docs/helloid/9d294ac38808f-delete-a-user)                              | Delete user accounts (DELETE)       |
-| [/api/v1/groups](https://apidocs.helloid.com/docs/helloid/15f7f74779d57-get-all-groups)                                     | Get all groups (GET)                |
-| [/api/v1/users/{UserId}/groups](https://apidocs.helloid.com/docs/helloid/575c5cde6e378-link-a-user-to-a-group)              | Grant group to user (POST)          |
-| [/api/v1/{UserId}/groups/{GroupId}](https://apidocs.helloid.com/docs/helloid/403a836a09d77-unlink-a-user-from-a-group)      | Revoke group from user (DELETE)     |
-| [/api/v1/groups](https://tools4ever.stoplight.io/docs/helloid/0b84c01989115-add-a-group)                                    | Create groups (POST)                |
-| [/api/v1/selfservice/products](https://apidocs.helloid.com/docs/helloid/ddbf642b3d115-get-all-products)                     | Get all products (GET)              |
-| [/api/v1/selfservice/products/request](https://apidocs.helloid.com/docs/helloid/5fff6c1a37337-request-a-product-for-a-user) | Request a product for a user (POST) |
+| Endpoint                                                                                                                                                | Description                           |
+|---------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
+| [/api/v1/users/{UserId}](https://apidocs.helloid.com/docs/helloid/562f51f234ff9-get-a-user)                                                             | Get specific user account (GET)       |
+| [/api/v1/users/](https://apidocs.helloid.com/docs/helloid/7d9592b2cfeed-add-a-user)                                                                     | Create user accounts (POST)           |
+| [/api/v1/users/{UserId}](https://apidocs.helloid.com/docs/helloid/b432862fd92c6-update-a-user)                                                          | Update user accounts (PUT)            |
+| [/api/v1/users/{UserId}](https://apidocs.helloid.com/docs/helloid/9d294ac38808f-delete-a-user)                                                          | Delete user accounts (DELETE)         |
+| [/api/v1/groups](https://apidocs.helloid.com/docs/helloid/15f7f74779d57-get-all-groups)                                                                 | Get all groups (GET)                  |
+| [/api/v1/users/{UserId}/groups](https://apidocs.helloid.com/docs/helloid/575c5cde6e378-link-a-user-to-a-group)                                          | Grant group to user (POST)            |
+| [/api/v1/{UserId}/groups/{GroupId}](https://apidocs.helloid.com/docs/helloid/403a836a09d77-unlink-a-user-from-a-group)                                  | Revoke group from user (DELETE)       |
+| [/api/v1/groups](https://tools4ever.stoplight.io/docs/helloid/0b84c01989115-add-a-group)                                                                | Create groups (POST)                  |
+| [/api/v1/selfservice/products](https://apidocs.helloid.com/docs/helloid/ddbf642b3d115-get-all-products)                                                 | Get all products (GET)                |
+| [/api/v1/selfservice/products/request](https://apidocs.helloid.com/docs/helloid/5fff6c1a37337-request-a-product-for-a-user)                             | Request a product for a user (POST)   |
+| [/api/v1/product-assignment/by-user/{UserId}](https://apidocs.helloid.com/docs/helloid/4e2983878a3b3-get-product-assignments-by-user)                   | Get product assignments by user (GET) |
+| [/api/v1/product-assignment/unassign/by-product](https://apidocs.helloid.com/docs/helloid/00377615a7e6f-unassign-a-product-from-a-user-by-product-guid) | Unassign a product from a user (POST) |
 
 The following lifecycle actions are available:
 
-| Action                        | Description                                                                                          |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------- |
-| create.ps1                    | Create or correlate to an account                                                                    |
-| delete.ps1                    | Delete an account                                                                                    |
-| disable.ps1                   | Disable an account                                                                                   |
-| enable.ps1                    | Enable an account                                                                                    |
-| update.ps1                    | Update an account                                                                                    |
-| permissions.groups.ps1        | List groups as permissions                                                                           |
-| grantPermission.groups.ps1    | Grant groupmembership to an account                                                                  |
-| revokePermission.groups.ps1   | Revoke groupmembership from an account                                                               |
-| permissions.products.ps1      | List products as permissions                                                                         |
-| grantPermission.products.ps1  | Request product for an account                                                                       |
-| revokePermission.products.ps1 | **Note:** there is no functionality to "unrequest" a product, therefore this is just an empty script |
-| resources.groups.ps1          | Create group based on HR data                                                                        |
-| configuration.json            | Default _configuration.json_                                                                         |
-| fieldMapping.json             | Default _fieldMapping.json_                                                                          |
+| Action                        | Description                            |
+|-------------------------------|----------------------------------------|
+| create.ps1                    | Create or correlate to an account      |
+| delete.ps1                    | Delete an account                      |
+| disable.ps1                   | Disable an account                     |
+| enable.ps1                    | Enable an account                      |
+| update.ps1                    | Update an account                      |
+| permissions.groups.ps1        | List groups as permissions             |
+| grantPermission.groups.ps1    | Grant groupmembership to an account    |
+| revokePermission.groups.ps1   | Revoke groupmembership from an account |
+| permissions.products.ps1      | List products as permissions           |
+| grantPermission.products.ps1  | Request product for an account         |
+| revokePermission.products.ps1 | Revoke product for an account          |
+| resources.groups.ps1          | Create group based on HR data          |
+| configuration.json            | Default _configuration.json_           |
+| fieldMapping.json             | Default _fieldMapping.json_            |
 
 ## Getting started
 By using this connector you will have the ability to seamlessly create and manage user accounts and groups in HelloID. Additionally, you can request products for users, enhancing your workflow. It's important to note that at this time, there isn't a feature to "unrequest" a product.
@@ -90,7 +92,7 @@ To properly setup the correlation:
 2. Specify the following configuration:
 
     | Setting                   | Value      |
-    | ------------------------- | ---------- |
+    |---------------------------|------------|
     | Enable correlation        | `True`     |
     | Person correlation field  | ``         |
     | Account correlation field | `UserName` |
@@ -107,7 +109,7 @@ The field mapping can be imported by using the _fieldMapping.json_ file.
 The following settings are required to connect to the API.
 
 | Setting        | Description                                                                                                                        | Mandatory |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------- | --------- |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------|-----------|
 | Base URL       | The URL to the API                                                                                                                 | Yes       |
 | Api key        | The key to connect to the API                                                                                                      | Yes       |
 | Api secret     | The secret to connect to the API                                                                                                   | Yes       |
@@ -123,7 +125,8 @@ The following settings are required to connect to the API.
   - [ ] API Secret
 
 ### Remarks
-> There is no functionality to "unrequest" a product, therefore this is just an empty script.
+> The product grant script only requests the product in case it has not been assigned for the account yet.
+> The product revoke script revokes all assignments for the requested product.
 
 ## Setup the connector
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ _HelloID-Conn-Prov-Target-HelloID_ is a _target_ connector. _HelloID_ provides a
 | [/api/v1/users/{UserId}](https://apidocs.helloid.com/docs/helloid/b432862fd92c6-update-a-user)                                                          | Update user accounts (PUT)            |
 | [/api/v1/users/{UserId}](https://apidocs.helloid.com/docs/helloid/9d294ac38808f-delete-a-user)                                                          | Delete user accounts (DELETE)         |
 | [/api/v1/groups](https://apidocs.helloid.com/docs/helloid/15f7f74779d57-get-all-groups)                                                                 | Get all groups (GET)                  |
-| [/api/v1/groups/{GroupId}](https://apidocs.helloid.com/docs/helloid/7affa2ddf0991-get-a-group)                                                          | Get specific groups (GET)             |
+| [/api/v1/groups/{GroupId}](https://apidocs.helloid.com/docs/helloid/7affa2ddf0991-get-a-group)                                                          | Get specific group (GET)              |
 | [/api/v1/users/{UserId}/groups](https://apidocs.helloid.com/docs/helloid/575c5cde6e378-link-a-user-to-a-group)                                          | Grant group to user (POST)            |
 | [/api/v1/{UserId}/groups/{GroupId}](https://apidocs.helloid.com/docs/helloid/403a836a09d77-unlink-a-user-from-a-group)                                  | Revoke group from user (DELETE)       |
 | [/api/v1/groups](https://apidocs.helloid.com/docs/helloid/0b84c01989115-add-a-group)                                                                    | Create groups (POST)                  |
 | [/api/v1/products](https://apidocs.helloid.com/docs/helloid/vq8nwsnjs8wjt-get-all-products)                                                             | Get all products (GET)                |
 | [/api/v1/selfservice/products/request](https://apidocs.helloid.com/docs/helloid/5fff6c1a37337-request-a-product-for-a-user)                             | Request a product for a user (POST)   |
+| [/api/v1/product-assignment](https://apidocs.helloid.com/docs/helloid/74ff8632aaa8c-get-all-product-assignments)                                        | Get all product assignments (GET)     |
 | [/api/v1/product-assignment/by-user/{UserId}](https://apidocs.helloid.com/docs/helloid/4e2983878a3b3-get-product-assignments-by-user)                   | Get product assignments by user (GET) |
 | [/api/v1/product-assignment/unassign/by-product](https://apidocs.helloid.com/docs/helloid/00377615a7e6f-unassign-a-product-from-a-user-by-product-guid) | Unassign a product from a user (POST) |
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ _HelloID-Conn-Prov-Target-HelloID_ is a _target_ connector. _HelloID_ provides a
 
 | Endpoint                                                                                                                                                | Description                           |
 |---------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
+| [/api/v1/users](https://apidocs.helloid.com/docs/helloid/041932dd2ca73-get-all-users)                                                                   | Get all user accounts (GET)           |
 | [/api/v1/users/{UserId}](https://apidocs.helloid.com/docs/helloid/562f51f234ff9-get-a-user)                                                             | Get specific user account (GET)       |
 | [/api/v1/users/](https://apidocs.helloid.com/docs/helloid/7d9592b2cfeed-add-a-user)                                                                     | Create user accounts (POST)           |
 | [/api/v1/users/{UserId}](https://apidocs.helloid.com/docs/helloid/b432862fd92c6-update-a-user)                                                          | Update user accounts (PUT)            |
@@ -38,7 +39,7 @@ _HelloID-Conn-Prov-Target-HelloID_ is a _target_ connector. _HelloID_ provides a
 | [/api/v1/groups](https://apidocs.helloid.com/docs/helloid/15f7f74779d57-get-all-groups)                                                                 | Get all groups (GET)                  |
 | [/api/v1/users/{UserId}/groups](https://apidocs.helloid.com/docs/helloid/575c5cde6e378-link-a-user-to-a-group)                                          | Grant group to user (POST)            |
 | [/api/v1/{UserId}/groups/{GroupId}](https://apidocs.helloid.com/docs/helloid/403a836a09d77-unlink-a-user-from-a-group)                                  | Revoke group from user (DELETE)       |
-| [/api/v1/groups](https://tools4ever.stoplight.io/docs/helloid/0b84c01989115-add-a-group)                                                                | Create groups (POST)                  |
+| [/api/v1/groups](https://apidocs.helloid.com/docs/helloid/0b84c01989115-add-a-group)                                                                    | Create groups (POST)                  |
 | [/api/v1/selfservice/products](https://apidocs.helloid.com/docs/helloid/ddbf642b3d115-get-all-products)                                                 | Get all products (GET)                |
 | [/api/v1/selfservice/products/request](https://apidocs.helloid.com/docs/helloid/5fff6c1a37337-request-a-product-for-a-user)                             | Request a product for a user (POST)   |
 | [/api/v1/product-assignment/by-user/{UserId}](https://apidocs.helloid.com/docs/helloid/4e2983878a3b3-get-product-assignments-by-user)                   | Get product assignments by user (GET) |

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ _HelloID-Conn-Prov-Target-HelloID_ is a _target_ connector. _HelloID_ provides a
 | [/api/v1/users/{UserId}](https://apidocs.helloid.com/docs/helloid/b432862fd92c6-update-a-user)                                                          | Update user accounts (PUT)            |
 | [/api/v1/users/{UserId}](https://apidocs.helloid.com/docs/helloid/9d294ac38808f-delete-a-user)                                                          | Delete user accounts (DELETE)         |
 | [/api/v1/groups](https://apidocs.helloid.com/docs/helloid/15f7f74779d57-get-all-groups)                                                                 | Get all groups (GET)                  |
-| [/api/v1/groups/{GroupId}](https://apidocs.helloid.com/docs/helloid/7affa2ddf0991-get-a-group)                                                          | Get specific groups (GET)             |
+| [/api/v1/groups/{GroupId}](https://apidocs.helloid.com/docs/helloid/7affa2ddf0991-get-a-group)                                                          | Get specific group(GET)               |
 | [/api/v1/users/{UserId}/groups](https://apidocs.helloid.com/docs/helloid/575c5cde6e378-link-a-user-to-a-group)                                          | Grant group to user (POST)            |
 | [/api/v1/{UserId}/groups/{GroupId}](https://apidocs.helloid.com/docs/helloid/403a836a09d77-unlink-a-user-from-a-group)                                  | Revoke group from user (DELETE)       |
 | [/api/v1/groups](https://apidocs.helloid.com/docs/helloid/0b84c01989115-add-a-group)                                                                    | Create groups (POST)                  |
-| [/api/v1/selfservice/products](https://apidocs.helloid.com/docs/helloid/ddbf642b3d115-get-all-products)                                                 | Get all products (GET)                |
+| [/api/v1/products](https://apidocs.helloid.com/docs/helloid/vq8nwsnjs8wjt-get-all-products)                                                             | Get all products (GET)                |
 | [/api/v1/selfservice/products/request](https://apidocs.helloid.com/docs/helloid/5fff6c1a37337-request-a-product-for-a-user)                             | Request a product for a user (POST)   |
 | [/api/v1/product-assignment/by-user/{UserId}](https://apidocs.helloid.com/docs/helloid/4e2983878a3b3-get-product-assignments-by-user)                   | Get product assignments by user (GET) |
 | [/api/v1/product-assignment/unassign/by-product](https://apidocs.helloid.com/docs/helloid/00377615a7e6f-unassign-a-product-from-a-user-by-product-guid) | Unassign a product from a user (POST) |

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ _HelloID-Conn-Prov-Target-HelloID_ is a _target_ connector. _HelloID_ provides a
 | [/api/v1/users/{UserId}](https://apidocs.helloid.com/docs/helloid/b432862fd92c6-update-a-user)                                                          | Update user accounts (PUT)            |
 | [/api/v1/users/{UserId}](https://apidocs.helloid.com/docs/helloid/9d294ac38808f-delete-a-user)                                                          | Delete user accounts (DELETE)         |
 | [/api/v1/groups](https://apidocs.helloid.com/docs/helloid/15f7f74779d57-get-all-groups)                                                                 | Get all groups (GET)                  |
+| [/api/v1/groups/{GroupId}](https://apidocs.helloid.com/docs/helloid/7affa2ddf0991-get-a-group)                                                          | Get specific groups (GET)             |
 | [/api/v1/users/{UserId}/groups](https://apidocs.helloid.com/docs/helloid/575c5cde6e378-link-a-user-to-a-group)                                          | Grant group to user (POST)            |
 | [/api/v1/{UserId}/groups/{GroupId}](https://apidocs.helloid.com/docs/helloid/403a836a09d77-unlink-a-user-from-a-group)                                  | Revoke group from user (DELETE)       |
 | [/api/v1/groups](https://apidocs.helloid.com/docs/helloid/0b84c01989115-add-a-group)                                                                    | Create groups (POST)                  |

--- a/configuration.json
+++ b/configuration.json
@@ -52,15 +52,5 @@
       "required": false,
       "description": ""
     }
-  },
-  {
-    "key": "isDebug",
-    "type": "checkbox",
-    "defaultValue": false,
-    "templateOptions": {
-      "label": "Toggle debug logging",
-      "description": "When toggled, debug logging will be displayed",
-      "required": false
-    }
   }
 ]

--- a/create.ps1
+++ b/create.ps1
@@ -6,14 +6,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Invoke-HelloIDRestMethod {
     [CmdletBinding()]
@@ -69,7 +61,7 @@ function Invoke-HelloIDRestMethod {
             }
 
             if ($Body) {
-                Write-Verbose "Adding body to request in utf8 byte encoding"
+                Write-Information "Adding body to request in utf8 byte encoding"
                 $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
             }
 
@@ -176,7 +168,7 @@ $outputContext.AccountReference = "Currently not available"
 try {
     # Create authorization headers with HelloID API key
     try {
-        Write-Verbose "Creating authorization headers with HelloID API key"
+        Write-Information "Creating authorization headers with HelloID API key"
 
         $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
         $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
@@ -184,7 +176,7 @@ try {
         $key = "Basic $base64"
         $headers = @{"authorization" = $Key }
 
-        Write-Verbose "Created authorization headers with HelloID API key"
+        Write-Information "Created authorization headers with HelloID API key"
     }
     catch {
         $ex = $PSItem
@@ -222,7 +214,7 @@ try {
     
         # Verify if a user must be either [created ] or just [correlated]
         try {
-            Write-Verbose "Querying account where [$($correlationField)] = [$($correlationValue)]"
+            Write-Information "Querying account where [$($correlationField)] = [$($correlationValue)]"
             $queryUserSplatParams = @{
                 Uri         = "$($actionContext.Configuration.baseUrl)/users/$correlationValue"
                 Headers     = $headers
@@ -293,8 +285,8 @@ try {
                 }
 
                 if (-Not($actionContext.DryRun -eq $true)) {
-                    Write-Verbose "Creating account [$($account.Username)]"
-                    Write-Verbose "Body: $($createUserSplatParams.body)"
+                    Write-Information "Creating account [$($account.Username)]"
+                    Write-Information "Body: $($createUserSplatParams.body)"
 
                     $createdAccount = Invoke-HelloIDRestMethod @createUserSplatParams
                     $createdAccount | Add-Member -MemberType NoteProperty -Name 'password' -Value $actionContext.Data.password

--- a/create.ps1
+++ b/create.ps1
@@ -211,13 +211,13 @@ try {
     # Validate correlation configuration
     if ($actionContext.CorrelationConfiguration.Enabled) {
         $correlationField = $actionContext.CorrelationConfiguration.accountField
-        $correlationValue = $actionContext.CorrelationConfiguration.accountFieldValue
+        $correlationValue = $actionContext.CorrelationConfiguration.personFieldValue
 
         if ([string]::IsNullOrEmpty($($correlationField))) {
             throw "Correlation is enabled but not configured correctly"
         }
         if ([string]::IsNullOrEmpty($($correlationValue))) {
-            throw "Correlation is enabled but [accountFieldValue] is empty. Please make sure it is correctly mapped"
+            throw "Correlation is enabled but [personFieldValue] is empty. Please make sure it is correctly mapped"
         }
     
         # Verify if a user must be either [created ] or just [correlated]

--- a/create.ps1
+++ b/create.ps1
@@ -297,6 +297,7 @@ try {
                     Write-Verbose "Body: $($createUserSplatParams.body)"
 
                     $createdAccount = Invoke-HelloIDRestMethod @createUserSplatParams
+                    $createdAccount | Add-Member -MemberType NoteProperty -Name 'password' -Value $actionContext.Data.password
                     $outputContext.AccountReference = $createdAccount.userGUID
                     $outputContext.Data = $createdAccount
 

--- a/delete.ps1
+++ b/delete.ps1
@@ -6,14 +6,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Invoke-HelloIDRestMethod {
     [CmdletBinding()]
@@ -69,7 +61,7 @@ function Invoke-HelloIDRestMethod {
             }
 
             if ($Body) {
-                Write-Verbose "Adding body to request in utf8 byte encoding"
+                Write-Information "Adding body to request in utf8 byte encoding"
                 $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
             }
 
@@ -160,7 +152,7 @@ try {
 
     # Create authorization headers with HelloID API key
     try {
-        Write-Verbose "Creating authorization headers with HelloID API key"
+        Write-Information "Creating authorization headers with HelloID API key"
 
         $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
         $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
@@ -168,7 +160,7 @@ try {
         $key = "Basic $base64"
         $headers = @{"authorization" = $Key }
 
-        Write-Verbose "Created authorization headers with HelloID API key"
+        Write-Information "Created authorization headers with HelloID API key"
     }
     catch {
         $ex = $PSItem
@@ -194,7 +186,7 @@ try {
 
     # Get current account
     try {
-        Write-Verbose "Querying account where [$($correlationField)] = [$($correlationValue)]"
+        Write-Information "Querying account where [$($correlationField)] = [$($correlationValue)]"
         $queryUserSplatParams = @{
             Uri     = "$($actionContext.Configuration.baseUrl)/users/$correlationValue"
             Headers = $headers
@@ -258,7 +250,7 @@ try {
                 }
 
                 if (-Not($actionContext.DryRun -eq $true)) {
-                    Write-Verbose "Deleting account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                    Write-Information "Deleting account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
 
                     $deletedAccount = Invoke-HelloIDRestMethod @deleteUserSplatParams
 

--- a/disable.ps1
+++ b/disable.ps1
@@ -6,14 +6,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Invoke-HelloIDRestMethod {
     [CmdletBinding()]
@@ -69,7 +61,7 @@ function Invoke-HelloIDRestMethod {
             }
 
             if ($Body) {
-                Write-Verbose "Adding body to request in utf8 byte encoding"
+                Write-Information "Adding body to request in utf8 byte encoding"
                 $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
             }
 
@@ -188,7 +180,7 @@ try {
 
     # Create authorization headers with HelloID API key
     try {
-        Write-Verbose "Creating authorization headers with HelloID API key"
+        Write-Information "Creating authorization headers with HelloID API key"
 
         $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
         $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
@@ -196,7 +188,7 @@ try {
         $key = "Basic $base64"
         $headers = @{"authorization" = $Key }
 
-        Write-Verbose "Created authorization headers with HelloID API key"
+        Write-Information "Created authorization headers with HelloID API key"
     }
     catch {
         $ex = $PSItem
@@ -222,7 +214,7 @@ try {
 
     # Get current account
     try {
-        Write-Verbose "Querying account where [$($correlationField)] = [$($correlationValue)]"
+        Write-Information "Querying account where [$($correlationField)] = [$($correlationValue)]"
         $queryUserSplatParams = @{
             Uri     = "$($actionContext.Configuration.baseUrl)/users/$correlationValue"
             Headers = $headers
@@ -336,8 +328,8 @@ try {
                 }
                 
                 if (-Not($actionContext.DryRun -eq $true)) {
-                    Write-Verbose "Updating account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Account property(s) updated: [$($propertiesChanged.name -join ',')]"
-                    Write-Verbose "Body: $($updateUserSplatParams.Body)"
+                    Write-Information "Updating account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Account property(s) updated: [$($propertiesChanged.name -join ',')]"
+                    Write-Information "Body: $($updateUserSplatParams.Body)"
 
                     $updatedAccount = Invoke-HelloIDRestMethod @updateUserSplatParams
                     $outputContext.Data = $updatedAccount

--- a/disable.ps1
+++ b/disable.ps1
@@ -266,11 +266,11 @@ try {
     if (($correlatedAccount | Measure-Object).count -eq 1) {
         # Create reference object from correlated account and remove depth from userAttributes
         $referenceObject = $correlatedAccount.PSObject.Copy()
+        $outputContext.PreviousData = $correlatedAccount
         foreach ($userAttribute in $referenceObject.userAttributes.PSObject.Properties) {
             $referenceObject | Add-Member -MemberType NoteProperty -Name "userAttributes_$($userAttribute.Name)" -Value $userAttribute.Value -Force
         }
         $referenceObject.PSObject.Properties.remove("userAttributes")
-        $outputContext.PreviousData = $referenceObject
 
         # Create difference object from mapped account and remove depth from userAttributes
         $differenceObject = $account.PSObject.Copy()
@@ -280,20 +280,37 @@ try {
         $differenceObject.PSObject.Properties.remove("userAttributes")
 
         $propertiesToCompare = $differenceObject.PSObject.Properties.Name | Where-Object { $_ -ne "userGUID" }
+
+        # Ensure that all properties that are being compared exist on the reference object, if not add them with null value (to ensure they are included in Compare-Object)
+        foreach ($missingProperties in $propertiesToCompare) {
+            if (-not($referenceObject."$missingProperties")) {
+                $referenceObject | Add-Member -MemberType NoteProperty -Name $missingProperties -Value $null -Force
+            }
+        }
         $splatCompareProperties = @{
             ReferenceObject  = $referenceObject.PSObject.Properties | Where-Object { $_.Name -in $propertiesToCompare }
             DifferenceObject = $differenceObject.PSObject.Properties | Where-Object { $_.Name -in $propertiesToCompare }
         }
-        $propertiesChanged = Compare-Object @splatCompareProperties -PassThru
-        $oldProperties = $propertiesChanged.Where( { $_.SideIndicator -eq '<=' })
-        $newProperties = $propertiesChanged.Where( { $_.SideIndicator -eq '=>' })
-
-        if ($newProperties) {
+        if (-not $splatCompareProperties.ReferenceObject) {
+            Write-Information "ReferenceObject is null. Proceeding with UpdateAccount."
             $action = "UpdateAccount"
-            Write-Information "Account property(s) required to update: $($newProperties.Name -join ', ')"
+        }
+        elseif (-not $splatCompareProperties.DifferenceObject) {
+            Write-Information "DifferenceObject is null. No changes to process."
+            $action = "NoChanges"
         }
         else {
-            $action = "NoChanges"
+            $propertiesChanged = Compare-Object @splatCompareProperties -PassThru
+            $oldProperties = $propertiesChanged.Where( { $_.SideIndicator -eq '<=' })
+            $newProperties = $propertiesChanged.Where( { $_.SideIndicator -eq '=>' })
+
+            if ($newProperties) {
+                $action = "UpdateAccount"
+                Write-Information "Account property(s) required to update: $($newProperties.Name -join ', ')"
+            }
+            else {
+                $action = "NoChanges"
+            }
         }
     }
     elseif (($correlatedAccount | Measure-Object).count -gt 1) {

--- a/disable.ps1
+++ b/disable.ps1
@@ -271,16 +271,16 @@ try {
             $referenceObject | Add-Member -MemberType NoteProperty -Name "userAttributes_$($userAttribute.Name)" -Value $userAttribute.Value -Force
         }
         $referenceObject.PSObject.Properties.remove("userAttributes")
-
+        
         # Create difference object from mapped account and remove depth from userAttributes
         $differenceObject = $account.PSObject.Copy()
         foreach ($userAttribute in $differenceObject.userAttributes.PSObject.Properties) {
             $differenceObject | Add-Member -MemberType NoteProperty -Name "userAttributes_$($userAttribute.Name)" -Value $userAttribute.Value -Force
         }
         $differenceObject.PSObject.Properties.remove("userAttributes")
-
+        
         $propertiesToCompare = $differenceObject.PSObject.Properties.Name | Where-Object { $_ -ne "userGUID" }
-
+        
         # Ensure that all properties that are being compared exist on the reference object, if not add them with null value (to ensure they are included in Compare-Object)
         foreach ($missingProperties in $propertiesToCompare) {
             if (-not($referenceObject."$missingProperties")) {
@@ -291,26 +291,12 @@ try {
             ReferenceObject  = $referenceObject.PSObject.Properties | Where-Object { $_.Name -in $propertiesToCompare }
             DifferenceObject = $differenceObject.PSObject.Properties | Where-Object { $_.Name -in $propertiesToCompare }
         }
-        if (-not $splatCompareProperties.ReferenceObject) {
-            Write-Information "ReferenceObject is null. Proceeding with UpdateAccount."
-            $action = "UpdateAccount"
-        }
-        elseif (-not $splatCompareProperties.DifferenceObject) {
-            Write-Information "DifferenceObject is null. No changes to process."
-            $action = "NoChanges"
+        $propertiesChanged = Compare-Object @splatCompareProperties -PassThru | Where-Object { $_.SideIndicator -eq '=>' }
+        if ($propertiesChanged) {
+            $action = 'UpdateAccount'
         }
         else {
-            $propertiesChanged = Compare-Object @splatCompareProperties -PassThru
-            $oldProperties = $propertiesChanged.Where( { $_.SideIndicator -eq '<=' })
-            $newProperties = $propertiesChanged.Where( { $_.SideIndicator -eq '=>' })
-
-            if ($newProperties) {
-                $action = "UpdateAccount"
-                Write-Information "Account property(s) required to update: $($newProperties.Name -join ', ')"
-            }
-            else {
-                $action = "NoChanges"
-            }
+            $action = 'NoChanges'
         }
     }
     elseif (($correlatedAccount | Measure-Object).count -gt 1) {
@@ -319,31 +305,17 @@ try {
     elseif (($correlatedAccount | Measure-Object).count -eq 0) {
         $action = "NotFound"
     }
-
+    
     # Process
     switch ($action) {
         "UpdateAccount" {
             # Update account
             try {
-                # Create custom object with old and new values (for logging)
-                $changedPropertiesObject = [PSCustomObject]@{
-                    OldValues = @{}
-                    NewValues = @{}
-                }
-
-                foreach ($oldProperty in ($oldProperties | Where-Object { $_.Name -in $newProperties.Name })) {
-                    $changedPropertiesObject.OldValues.$($oldProperty.Name) = $oldProperty.Value
-                }
-
-                foreach ($newProperty in $newProperties) {
-                    $changedPropertiesObject.NewValues.$($newProperty.Name) = $newProperty.Value
-                }
-
-                # Create account body and set with previous account data
-                $accountBody = $correlatedAccount.PSObject.Copy()
-
+                # Create account body and set with previous account data. Because of nested properties, we need to convert to json and back to create a deep copy of the object to avoid modifying the correlatedAccount object when adding updated properties to the account body
+                $accountBody = $correlatedAccount | ConvertTo-Json | ConvertFrom-Json
+                
                 # Add the updated properties to account body
-                foreach ($newProperty in $newProperties) {
+                foreach ($newProperty in $propertiesChanged) {
                     if ($newProperty.Name -eq "userName") {
                         $accountBody | Add-Member -MemberType NoteProperty -Name "IdentifierObject" -Value @{ userName = $newProperty.Value } -Force
                     }
@@ -354,7 +326,7 @@ try {
                         $accountBody.$($newProperty.Name) = $newProperty.Value
                     }
                 }
-
+                
                 $body = ($accountBody | ConvertTo-Json -Depth 10)
                 $updateUserSplatParams = @{
                     Uri     = "$($actionContext.Configuration.baseUrl)/users/$($correlatedAccount.userGuid)"
@@ -362,9 +334,9 @@ try {
                     Method  = "PUT"
                     Body    = $body
                 }
-
+                
                 if (-Not($actionContext.DryRun -eq $true)) {
-                    Write-Verbose "Updating account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Old values: $($changedPropertiesObject.oldValues | ConvertTo-Json). New values: $($changedPropertiesObject.newValues | ConvertTo-Json)"
+                    Write-Verbose "Updating account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Account property(s) updated: [$($propertiesChanged.name -join ',')]"
                     Write-Verbose "Body: $($updateUserSplatParams.Body)"
 
                     $updatedAccount = Invoke-HelloIDRestMethod @updateUserSplatParams
@@ -372,12 +344,12 @@ try {
 
                     $outputContext.AuditLogs.Add([PSCustomObject]@{
                             # Action  = "" # Optional
-                            Message = "Updated account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Old values: $($changedPropertiesObject.oldValues | ConvertTo-Json). New values: $($changedPropertiesObject.newValues | ConvertTo-Json)"
+                            Message = "Updated account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Account property(s) updated: [$($propertiesChanged.name -join ',')]"
                             IsError = $false
                         })
                 }
                 else {
-                    Write-Warning "DryRun: Would update account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Old values: $($changedPropertiesObject.oldValues | ConvertTo-Json). New values: $($changedPropertiesObject.newValues | ConvertTo-Json)"
+                    Write-Warning "DryRun: Would update account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Account property(s) updated: [$($propertiesChanged.name -join ',')]"
                     Write-Warning "DryRun: Body: $($updateUserSplatParams.Body)"
                 }
             }

--- a/enable.ps1
+++ b/enable.ps1
@@ -6,14 +6,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Invoke-HelloIDRestMethod {
     [CmdletBinding()]
@@ -69,7 +61,7 @@ function Invoke-HelloIDRestMethod {
             }
 
             if ($Body) {
-                Write-Verbose "Adding body to request in utf8 byte encoding"
+                Write-Information "Adding body to request in utf8 byte encoding"
                 $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
             }
 
@@ -188,7 +180,7 @@ try {
 
     # Create authorization headers with HelloID API key
     try {
-        Write-Verbose "Creating authorization headers with HelloID API key"
+        Write-Information "Creating authorization headers with HelloID API key"
 
         $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
         $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
@@ -196,7 +188,7 @@ try {
         $key = "Basic $base64"
         $headers = @{"authorization" = $Key }
 
-        Write-Verbose "Created authorization headers with HelloID API key"
+        Write-Information "Created authorization headers with HelloID API key"
     }
     catch {
         $ex = $PSItem
@@ -222,7 +214,7 @@ try {
 
     # Get current account
     try {
-        Write-Verbose "Querying account where [$($correlationField)] = [$($correlationValue)]"
+        Write-Information "Querying account where [$($correlationField)] = [$($correlationValue)]"
         $queryUserSplatParams = @{
             Uri     = "$($actionContext.Configuration.baseUrl)/users/$correlationValue"
             Headers = $headers
@@ -329,8 +321,8 @@ try {
                 }
 
                 if (-Not($actionContext.DryRun -eq $true)) {
-                    Write-Verbose "Updating account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Account property(s) updated: [$($propertiesChanged.name -join ',')]"
-                    Write-Verbose "Body: $($updateUserSplatParams.Body)"
+                    Write-Information "Updating account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Account property(s) updated: [$($propertiesChanged.name -join ',')]"
+                    Write-Information "Body: $($updateUserSplatParams.Body)"
 
                     $updatedAccount = Invoke-HelloIDRestMethod @updateUserSplatParams
                     $outputContext.Data = $updatedAccount

--- a/fieldMapping.json
+++ b/fieldMapping.json
@@ -2,19 +2,18 @@
   "Version": "v1",
   "MappingFields": [
     {
-      "Name": "firstName",
+      "Name": "mustChangePassword",
       "Description": "",
       "Type": "Text",
       "MappingActions": [
         {
           "MapForActions": [
-            "Create",
-            "Update"
+            "Create"
           ],
-          "MappingMode": "Field",
-          "Value": "\"Person.Name.NickName\"",
+          "MappingMode": "Fixed",
+          "Value": "\"TRUE\"",
           "UsedInNotifications": false,
-          "StoreInAccountData": true
+          "StoreInAccountData": false
         }
       ]
     },
@@ -35,40 +34,7 @@
       ]
     },
     {
-      "Name": "mustChangePassword",
-      "Description": "",
-      "Type": "Text",
-      "MappingActions": [
-        {
-          "MapForActions": [
-            "Create"
-          ],
-          "MappingMode": "Fixed",
-          "Value": "\"TRUE\"",
-          "UsedInNotifications": false,
-          "StoreInAccountData": false
-        }
-      ]
-    },
-    {
-      "Name": "managedByUserGUID",
-      "Description": "Set within script, as the aRef of manager is used.",
-      "Type": "Text",
-      "MappingActions": [
-        {
-          "MapForActions": [
-            "Create",
-            "Update"
-          ],
-          "MappingMode": "None",
-          "Value": "\"\"",
-          "UsedInNotifications": false,
-          "StoreInAccountData": true
-        }
-      ]
-    },
-    {
-      "Name": "userAttributes.title",
+      "Name": "firstName",
       "Description": "",
       "Type": "Text",
       "MappingActions": [
@@ -78,9 +44,43 @@
             "Update"
           ],
           "MappingMode": "Field",
-          "Value": "\"Person.PrimaryContract.Title.Name\"",
+          "Value": "\"Person.Name.NickName\"",
           "UsedInNotifications": false,
-          "StoreInAccountData": true
+          "StoreInAccountData": false
+        }
+      ]
+    },
+    {
+      "Name": "isEnabled",
+      "Description": "",
+      "Type": "Text",
+      "MappingActions": [
+        {
+          "MapForActions": [
+            "Create"
+          ],
+          "MappingMode": "Fixed",
+          "Value": "\"false\"",
+          "UsedInNotifications": false,
+          "StoreInAccountData": false
+        },
+        {
+          "MapForActions": [
+            "Enable"
+          ],
+          "MappingMode": "Fixed",
+          "Value": "\"true\"",
+          "UsedInNotifications": false,
+          "StoreInAccountData": false
+        },
+        {
+          "MapForActions": [
+            "Disable"
+          ],
+          "MappingMode": "Fixed",
+          "Value": "\"false\"",
+          "UsedInNotifications": false,
+          "StoreInAccountData": false
         }
       ]
     },
@@ -97,7 +97,41 @@
           "MappingMode": "Field",
           "Value": "\"Person.PrimaryContract.Department.DisplayName\"",
           "UsedInNotifications": false,
-          "StoreInAccountData": true
+          "StoreInAccountData": false
+        }
+      ]
+    },
+    {
+      "Name": "userAttributes.description",
+      "Description": "",
+      "Type": "Text",
+      "MappingActions": [
+        {
+          "MapForActions": [
+            "Create"
+          ],
+          "MappingMode": "Fixed",
+          "Value": "\"Created by HelloID Provisioning\"",
+          "UsedInNotifications": false,
+          "StoreInAccountData": false
+        },
+        {
+          "MapForActions": [
+            "Enable"
+          ],
+          "MappingMode": "Fixed",
+          "Value": "\"Enabled by HelloID Provisioning\"",
+          "UsedInNotifications": false,
+          "StoreInAccountData": false
+        },
+        {
+          "MapForActions": [
+            "Disable"
+          ],
+          "MappingMode": "Fixed",
+          "Value": "\"Disabled by HelloID Provisioning\"",
+          "UsedInNotifications": false,
+          "StoreInAccountData": false
         }
       ]
     },
@@ -114,7 +148,41 @@
           "MappingMode": "Field",
           "Value": "\"Person.Contact.Business.Phone.Mobile\"",
           "UsedInNotifications": false,
-          "StoreInAccountData": true
+          "StoreInAccountData": false
+        }
+      ]
+    },
+    {
+      "Name": "userAttributes.title",
+      "Description": "",
+      "Type": "Text",
+      "MappingActions": [
+        {
+          "MapForActions": [
+            "Create",
+            "Update"
+          ],
+          "MappingMode": "Field",
+          "Value": "\"Person.PrimaryContract.Title.Name\"",
+          "UsedInNotifications": false,
+          "StoreInAccountData": false
+        }
+      ]
+    },
+    {
+      "Name": "contactEmail",
+      "Description": "",
+      "Type": "Text",
+      "MappingActions": [
+        {
+          "MapForActions": [
+            "Create",
+            "Update"
+          ],
+          "MappingMode": "Complex",
+          "Value": "\"function getContactEmail() {\\n    let contactEmail = Person.Accounts.MicrosoftAzureAD.mail;\\n    return contactEmail;\\n}\\n\\ngetContactEmail();\"",
+          "UsedInNotifications": false,
+          "StoreInAccountData": false
         }
       ]
     },
@@ -132,9 +200,9 @@
             "Update"
           ],
           "MappingMode": "Complex",
-          "Value": "\"function getUserName() {\\r\\n    let userName = Person.Accounts.MicrosoftAzureAD.UserPrincipalName;\\r\\n    return userName;\\r\\n}\\r\\n\\r\\ngetUserName();\"",
+          "Value": "\"function getUserName() {\\r\\n    let userName = Person.Accounts.MicrosoftAzureAD.userPrincipalName;\\r\\n    return userName;\\r\\n}\\r\\n\\r\\ngetUserName();\"",
           "UsedInNotifications": false,
-          "StoreInAccountData": true
+          "StoreInAccountData": false
         }
       ]
     },
@@ -150,47 +218,13 @@
           "MappingMode": "Fixed",
           "Value": "\"Local\"",
           "UsedInNotifications": false,
-          "StoreInAccountData": true
+          "StoreInAccountData": false
         }
       ]
     },
     {
-      "Name": "isEnabled",
-      "Description": "",
-      "Type": "Text",
-      "MappingActions": [
-        {
-          "MapForActions": [
-            "Create"
-          ],
-          "MappingMode": "Fixed",
-          "Value": "\"false\"",
-          "UsedInNotifications": false,
-          "StoreInAccountData": true
-        },
-        {
-          "MapForActions": [
-            "Enable"
-          ],
-          "MappingMode": "Fixed",
-          "Value": "\"true\"",
-          "UsedInNotifications": false,
-          "StoreInAccountData": true
-        },
-        {
-          "MapForActions": [
-            "Disable"
-          ],
-          "MappingMode": "Fixed",
-          "Value": "\"false\"",
-          "UsedInNotifications": false,
-          "StoreInAccountData": true
-        }
-      ]
-    },
-    {
-      "Name": "contactEmail",
-      "Description": "",
+      "Name": "managedByUserGUID",
+      "Description": "Set within script, as the aRef of manager is used.",
       "Type": "Text",
       "MappingActions": [
         {
@@ -198,10 +232,10 @@
             "Create",
             "Update"
           ],
-          "MappingMode": "Complex",
-          "Value": "\"function getContactEmail() {\\n    let contactEmail = Person.Accounts.MicrosoftAzureAD.mail;\\n    return contactEmail;\\n}\\n\\ngetContactEmail();\"",
+          "MappingMode": "None",
+          "Value": "null",
           "UsedInNotifications": false,
-          "StoreInAccountData": true
+          "StoreInAccountData": false
         }
       ]
     },
@@ -212,45 +246,10 @@
       "MappingActions": [
         {
           "MapForActions": [
-            "Create",
-            "Update"
-          ],
-          "MappingMode": "None",
-          "Value": "\"\"",
-          "UsedInNotifications": false,
-          "StoreInAccountData": true
-        }
-      ]
-    },
-    {
-      "Name": "userAttributes.description",
-      "Description": "",
-      "Type": "Text",
-      "MappingActions": [
-        {
-          "MapForActions": [
             "Create"
           ],
-          "MappingMode": "Fixed",
-          "Value": "\"Created by HelloID Provisioning\"",
-          "UsedInNotifications": false,
-          "StoreInAccountData": true
-        },
-        {
-          "MapForActions": [
-            "Enable"
-          ],
-          "MappingMode": "Fixed",
-          "Value": "\"Enabled by HelloID Provisioning\"",
-          "UsedInNotifications": false,
-          "StoreInAccountData": true
-        },
-        {
-          "MapForActions": [
-            "Disable"
-          ],
-          "MappingMode": "Fixed",
-          "Value": "\"Disabled by HelloID Provisioning\"",
+          "MappingMode": "None",
+          "Value": "null",
           "UsedInNotifications": false,
           "StoreInAccountData": true
         }

--- a/import.ps1
+++ b/import.ps1
@@ -1,0 +1,235 @@
+#################################################
+# HelloID-Conn-Prov-Target-HelloID-Import
+# PowerShell V2
+#################################################
+
+# Enable TLS1.2
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+
+# Set debug logging
+switch ($actionContext.Configuration.isDebug) {
+    $true { $VerbosePreference = "Continue" }
+    $false { $VerbosePreference = "SilentlyContinue" }
+}
+$InformationPreference = "Continue"
+$WarningPreference = "Continue"
+
+#region functions
+function Invoke-HelloIDRestMethod {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Method,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Uri,
+
+        [object]
+        $Body,
+
+        [string]
+        $ContentType = "application/json",
+
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary]
+        $Headers,
+
+        [Parameter()]
+        [Boolean]
+        $UsePaging = $false,
+
+        [Parameter()]
+        [Int]
+        $Skip = 0,
+
+        [Parameter()]
+        [Int]
+        $Take = 1000,
+
+        [Parameter()]
+        [Int]
+        $TimeoutSec = 60
+    )
+
+    process {
+        try {
+            $splatParams = @{
+                Uri             = $Uri
+                Headers         = $Headers
+                Method          = $Method
+                ContentType     = $ContentType
+                TimeoutSec      = 60
+                UseBasicParsing = $true
+                Verbose         = $false
+                ErrorAction     = "Stop"
+            }
+
+            if ($Body) {
+                Write-Verbose "Adding body to request in utf8 byte encoding"
+                $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
+            }
+
+            if ($UsePaging -eq $true) {
+                $result = [System.Collections.ArrayList]@()
+                $startUri = $splatParams.Uri
+                do {
+                    $splatParams["Uri"] = $startUri + "?take=$($take)&skip=$($skip)"
+                    $response = (Invoke-RestMethod @splatParams)
+                    if ([bool]($response.PSobject.Properties.name -eq "data")) {
+                        $response = $response.data
+                    }
+                    if ($response -is [array]) {
+                        [void]$result.AddRange($response)
+                    }
+                    else {
+                        [void]$result.Add($response)
+                    }
+        
+                    $skip += $take
+                } while (($response | Measure-Object).Count -eq $take)
+            }
+            else {
+                $result = Invoke-RestMethod @splatParams
+            }
+
+            Write-Output $result
+        }
+        catch {
+            throw $_
+        }
+    }
+}
+function Resolve-HelloIDError {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [object]
+        $ErrorObject
+    )
+    process {
+        $httpErrorObj = [PSCustomObject]@{
+            ScriptLineNumber = $ErrorObject.InvocationInfo.ScriptLineNumber
+            Line             = $ErrorObject.InvocationInfo.Line
+            ErrorDetails     = $ErrorObject.Exception.Message
+            FriendlyMessage  = $ErrorObject.Exception.Message
+        }
+        if (-not [string]::IsNullOrEmpty($ErrorObject.ErrorDetails.Message)) {
+            $httpErrorObj.ErrorDetails = $ErrorObject.ErrorDetails.Message
+        }
+        elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
+            if ($null -ne $ErrorObject.Exception.Response) {
+                $streamReaderResponse = [System.IO.StreamReader]::new($ErrorObject.Exception.Response.GetResponseStream()).ReadToEnd()
+                if (-not [string]::IsNullOrEmpty($streamReaderResponse)) {
+                    $httpErrorObj.ErrorDetails = $streamReaderResponse
+                }
+            }
+        }
+        try {
+            $errorDetailsObject = ($httpErrorObj.ErrorDetails | ConvertFrom-Json)
+            # error message can be either in [resultMsg] or [message]
+            if ([bool]($errorDetailsObject.PSobject.Properties.name -eq "resultMsg")) {
+                $httpErrorObj.FriendlyMessage = $errorDetailsObject.resultMsg
+            }
+            elseif ([bool]($errorDetailsObject.PSobject.Properties.name -eq "message")) {
+                $httpErrorObj.FriendlyMessage = $errorDetailsObject.message
+            }
+        }
+        catch {
+            $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails
+            Write-Warning $_.Exception.Message
+        }
+        Write-Output $httpErrorObj
+    }
+}
+#endregion
+
+# Create authorization headers with HelloID API key
+try {
+    Write-Verbose "Creating authorization headers with HelloID API key"
+
+    $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
+    $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
+    $base64 = [System.Convert]::ToBase64String($bytes)
+    $key = "Basic $base64"
+    $headers = @{"authorization" = $Key }
+
+    Write-Verbose "Created authorization headers with HelloID API key"
+}
+catch {
+    $ex = $PSItem
+    if ($($ex.Exception.GetType().FullName -eq "Microsoft.PowerShell.Commands.HttpResponseException") -or
+        $($ex.Exception.GetType().FullName -eq "System.Net.WebException")) {
+        $errorObj = Resolve-HelloIDError -ErrorObject $ex
+        $auditMessage = "Error creating authorization headers with HelloID API key. Error: $($errorObj.FriendlyMessage)"
+        Write-Warning "Error at Line [$($errorObj.ScriptLineNumber)]: $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
+    }
+    else {
+        $auditMessage = "Error creating authorization headers with HelloID API key. Error: $($ex.Exception.Message)"
+        Write-Warning "Error at Line [$($ex.InvocationInfo.ScriptLineNumber)]: $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
+    }
+    $outputContext.AuditLogs.Add([PSCustomObject]@{
+            # Action  = "" # Optional
+            Message = $auditMessage
+            IsError = $true
+        })
+
+    # Throw terminal error
+    throw $auditMessage 
+}
+
+try {
+    Write-Information 'Starting HelloID account entitlement import'
+
+    $take = 50
+    $skip = 0
+    do {
+        $splatImportAccountParams = @{
+            Uri     = "$($actionContext.Configuration.BaseUrl)/users?skip=$($skip)&take=$($take)"
+            Method  = 'GET'
+            Headers = $headers
+        }
+        $importedAccounts = Invoke-RestMethod @splatImportAccountParams
+        foreach ($importedAccount in $importedAccounts) {
+            # Making sure only fieldMapping fields are imported
+            $data = @{}
+            foreach ($field in $actionContext.ImportFields) {
+                $data[$field] = $importedAccount.$field
+            }
+
+            # Make sure the displayName has a value
+            $displayName = "$($importedAccount.firstName) $($importedAccount.lastName)".trim()
+            if ([string]::IsNullOrEmpty($displayName)) {
+                $displayName = $importedAccount.userGUID
+            }
+
+            # Return the result
+            Write-Output @{
+                AccountReference = $importedAccount.userName
+                displayName      = $displayName
+                UserName         = $importedAccount.userName
+                Enabled          = $importedAccount.isEnabled
+                Data             = $data
+            }
+        }
+        $skip += $take
+    } while ($importedAccounts.Count -eq $take -and $importedAccounts.Count -gt 0)
+   
+    Write-Information 'HelloID account entitlement import completed'
+}
+catch {
+    $ex = $PSItem
+    if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
+        $($ex.Exception.GetType().FullName -eq 'System.Net.WebException')) {
+        $errorObj = Resolve-HelloIDError -ErrorObject $ex
+        Write-Warning "Error at Line '$($errorObj.ScriptLineNumber)': $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
+        Write-Error "Could not import HelloID account entitlements. Error: $($errorObj.FriendlyMessage)"
+    }
+    else {
+        Write-Warning "Error at Line '$($ex.InvocationInfo.ScriptLineNumber)': $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
+        Write-Error "Could not import HelloID account entitlements. Error: $($ex.Exception.Message)"
+    }
+}

--- a/import.ps1
+++ b/import.ps1
@@ -6,14 +6,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Invoke-HelloIDRestMethod {
     [CmdletBinding()]
@@ -69,7 +61,7 @@ function Invoke-HelloIDRestMethod {
             }
 
             if ($Body) {
-                Write-Verbose "Adding body to request in utf8 byte encoding"
+                Write-Information "Adding body to request in utf8 byte encoding"
                 $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
             }
 
@@ -149,7 +141,7 @@ function Resolve-HelloIDError {
 
 # Create authorization headers with HelloID API key
 try {
-    Write-Verbose "Creating authorization headers with HelloID API key"
+    Write-Information "Creating authorization headers with HelloID API key"
 
     $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
     $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
@@ -157,7 +149,7 @@ try {
     $key = "Basic $base64"
     $headers = @{"authorization" = $Key }
 
-    Write-Verbose "Created authorization headers with HelloID API key"
+    Write-Information "Created authorization headers with HelloID API key"
 }
 catch {
     $ex = $PSItem

--- a/permissions/groups/grantPermission.ps1
+++ b/permissions/groups/grantPermission.ps1
@@ -255,19 +255,19 @@ try {
                 }
 
                 if (-Not($actionContext.DryRun -eq $true)) {
-                    Write-Verbose "Granting group: [$($actionContext.References.Permission.Name)] with groupGuid: [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                    Write-Verbose "Granting group: [$($actionContext.PermissionDisplayName)] with groupGuid: [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
                     Write-Verbose "Body: $($grantGroupMembershipSplatParams.Body)"
 
                     $grantedGroupMembership = Invoke-HelloIDRestMethod @grantGroupMembershipSplatParams
 
                     $outputContext.AuditLogs.Add([PSCustomObject]@{
                             # Action  = "" # Optional
-                            Message = "Granted group: [$($actionContext.References.Permission.Name)] with groupGuid: [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                            Message = "Granted group: [$($actionContext.PermissionDisplayName)] with groupGuid: [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
                             IsError = $false
                         })
                 }
                 else {
-                    Write-Warning "DryRun: Would grant group: [$($actionContext.References.Permission.Name)] with groupGuid: [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                    Write-Warning "DryRun: Would grant group: [$($actionContext.PermissionDisplayName)] with groupGuid: [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
                     Write-Warning "DryRun: Body: $($grantGroupMembershipSplatParams.Body)"
                 }
             }
@@ -276,11 +276,11 @@ try {
                 if ($($ex.Exception.GetType().FullName -eq "Microsoft.PowerShell.Commands.HttpResponseException") -or
                     $($ex.Exception.GetType().FullName -eq "System.Net.WebException")) {
                     $errorObj = Resolve-HelloIDError -ErrorObject $ex
-                    $auditMessage = "Error granting group: [$($actionContext.References.Permission.Name)] with groupGuid: [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Error: $($errorObj.FriendlyMessage)"
+                    $auditMessage = "Error granting group: [$($actionContext.PermissionDisplayName)] with groupGuid: [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Error: $($errorObj.FriendlyMessage)"
                     Write-Warning "Error at Line [$($errorObj.ScriptLineNumber)]: $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
                 }
                 else {
-                    $auditMessage = "Error granting group: [$($actionContext.References.Permission.Name)] with groupGuid: [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Error: $($ex.Exception.Message)"
+                    $auditMessage = "Error granting group: [$($actionContext.PermissionDisplayName)] with groupGuid: [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Error: $($ex.Exception.Message)"
                     Write-Warning "Error at Line [$($ex.InvocationInfo.ScriptLineNumber)]: $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
                 }
                 $outputContext.AuditLogs.Add([PSCustomObject]@{

--- a/permissions/groups/grantPermission.ps1
+++ b/permissions/groups/grantPermission.ps1
@@ -6,14 +6,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Invoke-HelloIDRestMethod {
     [CmdletBinding()]
@@ -69,7 +61,7 @@ function Invoke-HelloIDRestMethod {
             }
 
             if ($Body) {
-                Write-Verbose "Adding body to request in utf8 byte encoding"
+                Write-Information "Adding body to request in utf8 byte encoding"
                 $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
             }
 
@@ -160,7 +152,7 @@ try {
 
     # Create authorization headers with HelloID API key
     try {
-        Write-Verbose "Creating authorization headers with HelloID API key"
+        Write-Information "Creating authorization headers with HelloID API key"
 
         $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
         $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
@@ -168,7 +160,7 @@ try {
         $key = "Basic $base64"
         $headers = @{"authorization" = $Key }
 
-        Write-Verbose "Created authorization headers with HelloID API key"
+        Write-Information "Created authorization headers with HelloID API key"
     }
     catch {
         $ex = $PSItem
@@ -194,7 +186,7 @@ try {
 
     # Get current account
     try {
-        Write-Verbose "Querying account where [$($correlationField)] = [$($correlationValue)]"
+        Write-Information "Querying account where [$($correlationField)] = [$($correlationValue)]"
         $queryUserSplatParams = @{
             Uri     = "$($actionContext.Configuration.baseUrl)/users/$correlationValue"
             Headers = $headers
@@ -255,8 +247,8 @@ try {
                 }
 
                 if (-Not($actionContext.DryRun -eq $true)) {
-                    Write-Verbose "Granting group: [$($actionContext.PermissionDisplayName)] with groupGuid: [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
-                    Write-Verbose "Body: $($grantGroupMembershipSplatParams.Body)"
+                    Write-Information "Granting group: [$($actionContext.PermissionDisplayName)] with groupGuid: [$($actionContext.References.Permission.id)] to account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                    Write-Information "Body: $($grantGroupMembershipSplatParams.Body)"
 
                     $grantedGroupMembership = Invoke-HelloIDRestMethod @grantGroupMembershipSplatParams
 

--- a/permissions/groups/import.ps1
+++ b/permissions/groups/import.ps1
@@ -1,7 +1,7 @@
-#################################################
-# HelloID-Conn-Prov-Target-HelloID-Import
+####################################################################
+# HelloID-Conn-Prov-Target-HelloID-ImportPermissions-Group
 # PowerShell V2
-#################################################
+####################################################################
 
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
@@ -137,6 +137,7 @@ function Resolve-HelloIDError {
             elseif ([bool]($errorDetailsObject.PSobject.Properties.name -eq "message")) {
                 $httpErrorObj.FriendlyMessage = $errorDetailsObject.message
             }
+            $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails # Temporarily assignment
         }
         catch {
             $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails
@@ -182,42 +183,41 @@ catch {
 }
 
 try {
-    Write-Information 'Starting HelloID account entitlement import'
+    Write-Information 'Starting HelloID permission entitlement import'a
 
-    do {
-        $splatImportAccountParams = @{
-            Uri     = "$($actionContext.Configuration.BaseUrl)/users"
+    $splatImportGroupsParams = @{
+        Uri     = "$($actionContext.Configuration.BaseUrl)/groups"
+        Method  = 'GET'
+        Headers = $headers
+        UsePaging = $true
+    }
+    $importedGroups = Invoke-HelloIDRestMethod @splatImportGroupsParams
+
+    foreach ($importedGroup in $importedGroups) {
+        $splatImportGroupParams = @{
+            Uri     = "$($actionContext.Configuration.BaseUrl)/groups/$($importedGroup.groupGuid)"
             Method  = 'GET'
             Headers = $headers
-            UsePaging = $true
         }
-        $importedAccounts = Invoke-HelloIDRestMethod @splatImportAccountParams
-        foreach ($importedAccount in $importedAccounts) {
-            # Making sure only fieldMapping fields are imported
-            $data = @{}
-            foreach ($field in $actionContext.ImportFields) {
-                $data[$field] = $importedAccount.$field
+        $group = Invoke-HelloIDRestMethod @splatImportGroupParams
+        $permission = @{
+            PermissionReference = @{
+                Reference = $importedGroup.groupGuid
             }
-
-            # Make sure the displayName has a value
-            $displayName = "$($importedAccount.firstName) $($importedAccount.lastName)".trim()
-            if ([string]::IsNullOrEmpty($displayName)) {
-                $displayName = $importedAccount.userGUID
-            }
-
-            # Return the result
-            Write-Output @{
-                AccountReference = $importedAccount.userName
-                displayName      = $displayName
-                UserName         = $importedAccount.userName
-                Enabled          = $importedAccount.isEnabled
-                Data             = $data
-            }
+            DisplayName         = "$($importedGroup.name)"
+            AccountReferences   = $null
         }
-        $skip += $take
-    } while ($importedAccounts.Count -eq $take -and $importedAccounts.Count -gt 0)
-   
-    Write-Information 'HelloID account entitlement import completed'
+
+        # The code below splits a list of permission members into batches of 100
+        # Each batch is assigned to $permission.AccountReferences and the permission object will be returned to HelloID for each batch
+        # Ensure batching is based on the number of account references to prevent exceeding the maximum limit of 500 account references per batch
+        $batchSize = 500
+        for ($i = 0; $i -lt $group.users.Count; $i += $batchSize) {
+            $permission.AccountReferences = $group.users[$i..([Math]::Min($i + $batchSize - 1, $group.users.Count - 1))]
+            Write-Output $permission
+        }
+    }
+    Write-Information 'HelloID permission entitlement import completed'
 }
 catch {
     $ex = $PSItem
@@ -225,10 +225,10 @@ catch {
         $($ex.Exception.GetType().FullName -eq 'System.Net.WebException')) {
         $errorObj = Resolve-HelloIDError -ErrorObject $ex
         Write-Warning "Error at Line '$($errorObj.ScriptLineNumber)': $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
-        Write-Error "Could not import HelloID account entitlements. Error: $($errorObj.FriendlyMessage)"
+        Write-Error "Could not import HelloID permission entitlements. Error: $($errorObj.FriendlyMessage)"
     }
     else {
         Write-Warning "Error at Line '$($ex.InvocationInfo.ScriptLineNumber)': $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
-        Write-Error "Could not import HelloID account entitlements. Error: $($ex.Exception.Message)"
+        Write-Error "Could not import HelloID permission entitlements. Error: $($ex.Exception.Message)"
     }
 }

--- a/permissions/groups/import.ps1
+++ b/permissions/groups/import.ps1
@@ -6,14 +6,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Invoke-HelloIDRestMethod {
     [CmdletBinding()]
@@ -69,7 +61,7 @@ function Invoke-HelloIDRestMethod {
             }
 
             if ($Body) {
-                Write-Verbose "Adding body to request in utf8 byte encoding"
+                Write-Information "Adding body to request in utf8 byte encoding"
                 $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
             }
 
@@ -150,7 +142,7 @@ function Resolve-HelloIDError {
 
 # Create authorization headers with HelloID API key
 try {
-    Write-Verbose "Creating authorization headers with HelloID API key"
+    Write-Information "Creating authorization headers with HelloID API key"
 
     $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
     $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
@@ -158,7 +150,7 @@ try {
     $key = "Basic $base64"
     $headers = @{"authorization" = $Key }
 
-    Write-Verbose "Created authorization headers with HelloID API key"
+    Write-Information "Created authorization headers with HelloID API key"
 }
 catch {
     $ex = $PSItem

--- a/permissions/groups/import.ps1
+++ b/permissions/groups/import.ps1
@@ -202,7 +202,7 @@ try {
         $group = Invoke-HelloIDRestMethod @splatImportGroupParams
         $permission = @{
             PermissionReference = @{
-                Reference = $importedGroup.groupGuid
+                Id = $importedGroup.groupGuid
             }
             DisplayName         = "$($importedGroup.name)"
             AccountReferences   = $null

--- a/permissions/groups/importSubPermissions.ps1
+++ b/permissions/groups/importSubPermissions.ps1
@@ -14,14 +14,6 @@ $filterGroups = { $_.name -like "department_*" }
 # If all groups needs to be queried
 # $filterGroups = { $_ }
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Invoke-HelloIDRestMethod {
     [CmdletBinding()]
@@ -77,7 +69,7 @@ function Invoke-HelloIDRestMethod {
             }
 
             if ($Body) {
-                Write-Verbose "Adding body to request in utf8 byte encoding"
+                Write-Information "Adding body to request in utf8 byte encoding"
                 $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
             }
 
@@ -153,7 +145,7 @@ function Resolve-HelloIDError {
 
 # Create authorization headers with HelloID API key
 try {
-    Write-Verbose "Creating authorization headers with HelloID API key"
+    Write-Information "Creating authorization headers with HelloID API key"
 
     $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
     $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
@@ -161,7 +153,7 @@ try {
     $key = "Basic $base64"
     $headers = @{"authorization" = $Key }
 
-    Write-Verbose "Created authorization headers with HelloID API key"
+    Write-Information "Created authorization headers with HelloID API key"
 }
 catch {
     $ex = $PSItem

--- a/permissions/groups/importSubPermissions.ps1
+++ b/permissions/groups/importSubPermissions.ps1
@@ -1,0 +1,244 @@
+####################################################################
+# HelloID-Conn-Prov-Target-HelloID-ImportSubPermissions-Group
+# PowerShell V2
+####################################################################
+
+# Enable TLS1.2
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+
+# Configure, must be the same as the values used in retrieve permissions
+$permissionReference = 'dep'
+$permissionDisplayName = 'Afdeling'
+
+$filterGroups = { $_.name -like "department_*" }
+# If all groups needs to be queried
+# $filterGroups = { $_ }
+
+# Set debug logging
+switch ($actionContext.Configuration.isDebug) {
+    $true { $VerbosePreference = "Continue" }
+    $false { $VerbosePreference = "SilentlyContinue" }
+}
+$InformationPreference = "Continue"
+$WarningPreference = "Continue"
+
+#region functions
+function Invoke-HelloIDRestMethod {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Method,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Uri,
+
+        [object]
+        $Body,
+
+        [string]
+        $ContentType = "application/json",
+
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary]
+        $Headers,
+
+        [Parameter()]
+        [Boolean]
+        $UsePaging = $false,
+
+        [Parameter()]
+        [Int]
+        $Skip = 0,
+
+        [Parameter()]
+        [Int]
+        $Take = 1000,
+
+        [Parameter()]
+        [Int]
+        $TimeoutSec = 60
+    )
+
+    process {
+        try {
+            $splatParams = @{
+                Uri             = $Uri
+                Headers         = $Headers
+                Method          = $Method
+                ContentType     = $ContentType
+                TimeoutSec      = 60
+                UseBasicParsing = $true
+                Verbose         = $false
+                ErrorAction     = "Stop"
+            }
+
+            if ($Body) {
+                Write-Verbose "Adding body to request in utf8 byte encoding"
+                $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
+            }
+
+            if ($UsePaging -eq $true) {
+                $result = [System.Collections.ArrayList]@()
+                $startUri = $splatParams.Uri
+                do {
+                    $splatParams["Uri"] = $startUri + "?take=$($take)&skip=$($skip)"
+                    $response = (Invoke-RestMethod @splatParams)
+                    if ([bool]($response.PSobject.Properties.name -eq "data")) {
+                        $response = $response.data
+                    }
+                    if ($response -is [array]) {
+                        [void]$result.AddRange($response)
+                    }
+                    else {
+                        [void]$result.Add($response)
+                    }
+        
+                    $skip += $take
+                } while (($response | Measure-Object).Count -eq $take)
+            }
+            else {
+                $result = Invoke-RestMethod @splatParams
+            }
+
+            Write-Output $result
+        }
+        catch {
+            throw $_
+        }
+    }
+}
+function Resolve-HelloIDError {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [object]
+        $ErrorObject
+    )
+    process {
+        $httpErrorObj = [PSCustomObject]@{
+            ScriptLineNumber = $ErrorObject.InvocationInfo.ScriptLineNumber
+            Line             = $ErrorObject.InvocationInfo.Line
+            ErrorDetails     = $ErrorObject.Exception.Message
+            FriendlyMessage  = $ErrorObject.Exception.Message
+        }
+        if (-not [string]::IsNullOrEmpty($ErrorObject.ErrorDetails.Message)) {
+            $httpErrorObj.ErrorDetails = $ErrorObject.ErrorDetails.Message
+        }
+        elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
+            if ($null -ne $ErrorObject.Exception.Response) {
+                $streamReaderResponse = [System.IO.StreamReader]::new($ErrorObject.Exception.Response.GetResponseStream()).ReadToEnd()
+                if (-not [string]::IsNullOrEmpty($streamReaderResponse)) {
+                    $httpErrorObj.ErrorDetails = $streamReaderResponse
+                }
+            }
+        }
+        try {
+            $errorDetailsObject = ($httpErrorObj.ErrorDetails | ConvertFrom-Json)
+            # Make sure to inspect the error result object and add only the error message as a FriendlyMessage.
+            # $httpErrorObj.FriendlyMessage = $errorDetailsObject.message
+            $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails # Temporarily assignment
+        }
+        catch {
+            $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails
+            Write-Warning $_.Exception.Message
+        }
+        Write-Output $httpErrorObj
+    }
+}
+#endregion
+
+# Create authorization headers with HelloID API key
+try {
+    Write-Verbose "Creating authorization headers with HelloID API key"
+
+    $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
+    $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
+    $base64 = [System.Convert]::ToBase64String($bytes)
+    $key = "Basic $base64"
+    $headers = @{"authorization" = $Key }
+
+    Write-Verbose "Created authorization headers with HelloID API key"
+}
+catch {
+    $ex = $PSItem
+    if ($($ex.Exception.GetType().FullName -eq "Microsoft.PowerShell.Commands.HttpResponseException") -or
+        $($ex.Exception.GetType().FullName -eq "System.Net.WebException")) {
+        $errorObj = Resolve-HelloIDError -ErrorObject $ex
+        $auditMessage = "Error creating authorization headers with HelloID API key. Error: $($errorObj.FriendlyMessage)"
+        Write-Warning "Error at Line [$($errorObj.ScriptLineNumber)]: $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
+    }
+    else {
+        $auditMessage = "Error creating authorization headers with HelloID API key. Error: $($ex.Exception.Message)"
+        Write-Warning "Error at Line [$($ex.InvocationInfo.ScriptLineNumber)]: $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
+    }
+    $outputContext.AuditLogs.Add([PSCustomObject]@{
+            # Action  = "" # Optional
+            Message = $auditMessage
+            IsError = $true
+        })
+
+    # Throw terminal error
+    throw $auditMessage 
+}
+
+try {
+    Write-Information 'Starting HelloID permission entitlement import'
+
+    $splatImportGroupsParams = @{
+        Uri       = "$($actionContext.Configuration.BaseUrl)/groups"
+        Method    = 'GET'
+        Headers   = $headers
+        UsePaging = $true
+    }
+    $importedGroups = Invoke-HelloIDRestMethod @splatImportGroupsParams
+
+    #Filter imported groups based on configuration above.
+    $importedGroups = $importedGroups | Where-Object $filterGroups
+
+    foreach ($importedGroup in $importedGroups) {
+        $splatImportGroupParams = @{
+            Uri     = "$($actionContext.Configuration.BaseUrl)/groups/$($importedGroup.groupGuid)"
+            Method  = 'GET'
+            Headers = $headers
+        }
+        $group = Invoke-HelloIDRestMethod @splatImportGroupParams
+        $permission = @{
+            PermissionReference      = @{
+                Reference = $permissionReference
+            }
+            DisplayName              = $permissionDisplayName
+            AccountReferences        = $null
+            SubPermissionReference   = @{
+                Id = $importedGroup.groupGuid
+            }
+            SubPermissionDisplayName = "$($importedGroup.name)"
+        }
+
+        # The code below splits a list of permission members into batches of 100
+        # Each batch is assigned to $permission.AccountReferences and the permission object will be returned to HelloID for each batch
+        # Ensure batching is based on the number of account references to prevent exceeding the maximum limit of 500 account references per batch
+        $batchSize = 500
+        for ($i = 0; $i -lt $group.users.Count; $i += $batchSize) {
+            $permission.AccountReferences = $group.users[$i..([Math]::Min($i + $batchSize - 1, $group.users.Count - 1))]
+            Write-Output $permission
+        }
+    }
+    Write-Information 'HelloID permission entitlement import completed'
+}
+catch {
+    $ex = $PSItem
+    if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
+        $($ex.Exception.GetType().FullName -eq 'System.Net.WebException')) {
+        $errorObj = Resolve-HelloIDError -ErrorObject $ex
+        Write-Warning "Error at Line '$($errorObj.ScriptLineNumber)': $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
+        Write-Error "Could not import HelloID permission entitlements. Error: $($errorObj.FriendlyMessage)"
+    }
+    else {
+        Write-Warning "Error at Line '$($ex.InvocationInfo.ScriptLineNumber)': $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
+        Write-Error "Could not import HelloID permission entitlements. Error: $($ex.Exception.Message)"
+    }
+}

--- a/permissions/groups/permissions.ps1
+++ b/permissions/groups/permissions.ps1
@@ -6,14 +6,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Invoke-HelloIDRestMethod {
     [CmdletBinding()]
@@ -69,7 +61,7 @@ function Invoke-HelloIDRestMethod {
             }
 
             if ($Body) {
-                Write-Verbose "Adding body to request in utf8 byte encoding"
+                Write-Information "Adding body to request in utf8 byte encoding"
                 $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
             }
 
@@ -150,7 +142,7 @@ function Resolve-HelloIDError {
 try {
     # Create authorization headers with HelloID API key
     try {
-        Write-Verbose "Creating authorization headers with HelloID API key"
+        Write-Information "Creating authorization headers with HelloID API key"
 
         $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
         $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
@@ -158,7 +150,7 @@ try {
         $key = "Basic $base64"
         $headers = @{"authorization" = $Key }
 
-        Write-Verbose "Created authorization headers with HelloID API key"
+        Write-Information "Created authorization headers with HelloID API key"
     }
     catch {
         $ex = $PSItem
@@ -184,7 +176,7 @@ try {
 
     # Get groups
     try {
-        Write-Verbose 'Querying groups'
+        Write-Information 'Querying groups'
 
         $queryGroupsSplatParams = @{
             Uri       = "$($actionContext.Configuration.baseUrl)/groups"

--- a/permissions/groups/permissions.ps1
+++ b/permissions/groups/permissions.ps1
@@ -233,8 +233,6 @@ finally {
             DisplayName    = $displayName
             Identification = @{
                 Id   = $group.groupGuid
-                Name = $group.name
-                Type = "Group"
             }
         }
 

--- a/permissions/groups/resources.ps1
+++ b/permissions/groups/resources.ps1
@@ -15,6 +15,32 @@ $InformationPreference = "Continue"
 $WarningPreference = "Continue"
 
 #region functions
+function Get-ADSanitizedGroupName {
+    # The names of security principal objects can contain all Unicode characters except the special LDAP characters defined in RFC 2253.
+    # This list of special characters includes: a leading space a trailing space and any of the following characters: # , + " \ < > 
+    # A group account cannot consist solely of numbers, periods (.), or spaces. Any leading periods or spaces are cropped.
+    # https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc776019(v=ws.10)?redirectedfrom=MSDN
+    # https://www.ietf.org/rfc/rfc2253.txt    
+    param(
+        [parameter(Mandatory = $true)][String]$Name
+    )
+    $newName = $name.trim()
+    $newName = $newName -replace " - ", "-"
+    $newName = $newName -replace "[`,~,!,#,$,%,^,&,*,(,),+,=,<,>,?,/,',`",,:,\,|,},{,.]", ""
+    $newName = $newName -replace "\[", ""
+    $newName = $newName -replace "]", ""
+    $newName = $newName -replace " ", "-"
+    $newName = $newName -replace "--", "-"
+    $newName = $newName -replace "\.\.\.\.\.", "."
+    $newName = $newName -replace "\.\.\.\.", "."
+    $newName = $newName -replace "\.\.\.", "."
+    $newName = $newName -replace "\.\.", "."
+
+    # Remove diacritics
+    $newName = Remove-StringLatinCharacters $newName
+    
+    return $newName
+}
 function Invoke-HelloIDRestMethod {
     [CmdletBinding()]
     param (
@@ -237,7 +263,7 @@ try {
         Write-Verbose "Checking $($resource)"
         # Example: department_<department externalId>
         $groupName = "department_" + $resource.ExternalId
-        $groupName = Remove-StringLatinCharacters $groupName
+        $groupName = Get-ADSanitizedGroupName $groupName
 
         $correlationValue = $groupName
 

--- a/permissions/groups/resources.ps1
+++ b/permissions/groups/resources.ps1
@@ -6,14 +6,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Get-ADSanitizedGroupName {
     # The names of security principal objects can contain all Unicode characters except the special LDAP characters defined in RFC 2253.
@@ -95,7 +87,7 @@ function Invoke-HelloIDRestMethod {
             }
 
             if ($Body) {
-                Write-Verbose "Adding body to request in utf8 byte encoding"
+                Write-Information "Adding body to request in utf8 byte encoding"
                 $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
             }
 
@@ -185,7 +177,7 @@ $correlationField = "name"
 try {
     # Create authorization headers with HelloID API key
     try {
-        Write-Verbose "Creating authorization headers with HelloID API key"
+        Write-Information "Creating authorization headers with HelloID API key"
 
         $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
         $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
@@ -193,7 +185,7 @@ try {
         $key = "Basic $base64"
         $headers = @{"authorization" = $Key }
 
-        Write-Verbose "Created authorization headers with HelloID API key"
+        Write-Information "Created authorization headers with HelloID API key"
     }
     catch {
         $ex = $PSItem
@@ -219,7 +211,7 @@ try {
 
     # Get groups
     try {
-        Write-Verbose 'Querying groups'
+        Write-Information 'Querying groups'
 
         $queryGroupsSplatParams = @{
             Uri       = "$($actionContext.Configuration.baseUrl)/groups"
@@ -260,14 +252,14 @@ try {
 
 
     foreach ($resource in $resourceContext.SourceData) {
-        Write-Verbose "Checking $($resource)"
+        Write-Information "Checking $($resource)"
         # Example: department_<department externalId>
         $groupName = "department_" + $resource.ExternalId
         $groupName = Get-ADSanitizedGroupName $groupName
 
         $correlationValue = $groupName
 
-        Write-Verbose "Querying group where [$($correlationField)] = [$($correlationValue)]"
+        Write-Information "Querying group where [$($correlationField)] = [$($correlationValue)]"
 
         $correlatedResource = $null
         $correlatedResource = $groupsGrouped["$($correlationValue)"]
@@ -299,8 +291,8 @@ try {
                     }
 
                     if (-Not($actionContext.DryRun -eq $true)) {
-                        Write-Verbose "Creating group [$($groupName)]"
-                        Write-Verbose "Body: $($createGroupSplatParams.body)"
+                        Write-Information "Creating group [$($groupName)]"
+                        Write-Information "Body: $($createGroupSplatParams.body)"
 
                         $createdResource = Invoke-HelloIDRestMethod @createGroupSplatParams
 
@@ -312,7 +304,7 @@ try {
                     }
                     else {
                         Write-Warning "DryRun: Would create group [$($groupName)]"
-                        Write-Verbose "Body: $($createGroupSplatParams.body)"
+                        Write-Information "Body: $($createGroupSplatParams.body)"
                     }
                 }
                 catch {

--- a/permissions/groups/revokePermission.ps1
+++ b/permissions/groups/revokePermission.ps1
@@ -6,14 +6,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Invoke-HelloIDRestMethod {
     [CmdletBinding()]
@@ -69,7 +61,7 @@ function Invoke-HelloIDRestMethod {
             }
 
             if ($Body) {
-                Write-Verbose "Adding body to request in utf8 byte encoding"
+                Write-Information "Adding body to request in utf8 byte encoding"
                 $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
             }
 
@@ -160,7 +152,7 @@ try {
 
     # Create authorization headers with HelloID API key
     try {
-        Write-Verbose "Creating authorization headers with HelloID API key"
+        Write-Information "Creating authorization headers with HelloID API key"
 
         $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
         $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
@@ -168,7 +160,7 @@ try {
         $key = "Basic $base64"
         $headers = @{"authorization" = $Key }
 
-        Write-Verbose "Created authorization headers with HelloID API key"
+        Write-Information "Created authorization headers with HelloID API key"
     }
     catch {
         $ex = $PSItem
@@ -194,7 +186,7 @@ try {
 
     # Get current account
     try {
-        Write-Verbose "Querying account where [$($correlationField)] = [$($correlationValue)]"
+        Write-Information "Querying account where [$($correlationField)] = [$($correlationValue)]"
         $queryUserSplatParams = @{
             Uri     = "$($actionContext.Configuration.baseUrl)/users/$correlationValue"
             Headers = $headers
@@ -250,7 +242,7 @@ try {
                 }
 
                 if (-Not($actionContext.DryRun -eq $true)) {
-                    Write-Verbose "Revoking group: [$($actionContext.PermissionDisplayName)] with groupGuid: [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                    Write-Information "Revoking group: [$($actionContext.PermissionDisplayName)] with groupGuid: [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
 
                     $revokedGroupMembership = Invoke-HelloIDRestMethod @revokeGroupMembershipSplatParams
 

--- a/permissions/groups/revokePermission.ps1
+++ b/permissions/groups/revokePermission.ps1
@@ -250,18 +250,18 @@ try {
                 }
 
                 if (-Not($actionContext.DryRun -eq $true)) {
-                    Write-Verbose "Revoking group: [$($actionContext.References.Permission.Name)] with groupGuid: [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                    Write-Verbose "Revoking group: [$($actionContext.PermissionDisplayName)] with groupGuid: [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
 
                     $revokedGroupMembership = Invoke-HelloIDRestMethod @revokeGroupMembershipSplatParams
 
                     $outputContext.AuditLogs.Add([PSCustomObject]@{
                             # Action  = "" # Optional
-                            Message = "Revoked group: [$($actionContext.References.Permission.Name)] with groupGuid: [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                            Message = "Revoked group: [$($actionContext.PermissionDisplayName)] with groupGuid: [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
                             IsError = $false
                         })
                 }
                 else {
-                    Write-Warning "DryRun: Would revoke group: [$($actionContext.References.Permission.Name)] with groupGuid: [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                    Write-Warning "DryRun: Would revoke group: [$($actionContext.PermissionDisplayName)] with groupGuid: [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
                 }
             }
             catch {
@@ -269,11 +269,11 @@ try {
                 if ($($ex.Exception.GetType().FullName -eq "Microsoft.PowerShell.Commands.HttpResponseException") -or
                     $($ex.Exception.GetType().FullName -eq "System.Net.WebException")) {
                     $errorObj = Resolve-HelloIDError -ErrorObject $ex
-                    $auditMessage = "Error revoking group: [$($actionContext.References.Permission.Name)] with groupGuid: [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Error: $($errorObj.FriendlyMessage)"
+                    $auditMessage = "Error revoking group: [$($actionContext.PermissionDisplayName)] with groupGuid: [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Error: $($errorObj.FriendlyMessage)"
                     Write-Warning "Error at Line [$($errorObj.ScriptLineNumber)]: $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
                 }
                 else {
-                    $auditMessage = "Error revoking group: [$($actionContext.References.Permission.Name)] with groupGuid: [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Error: $($ex.Exception.Message)"
+                    $auditMessage = "Error revoking group: [$($actionContext.PermissionDisplayName)] with groupGuid: [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Error: $($ex.Exception.Message)"
                     Write-Warning "Error at Line [$($ex.InvocationInfo.ScriptLineNumber)]: $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
                 }
                 $outputContext.AuditLogs.Add([PSCustomObject]@{

--- a/permissions/groups/revokePermission.ps1
+++ b/permissions/groups/revokePermission.ps1
@@ -305,7 +305,7 @@ try {
         }
 
         "NotFound" {
-            $auditMessage = "Skipped revoking group: [$($actionContext.References.Permission.Name)] with groupGuid: [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Reason: No account found where [$($correlationField)] = [$($correlationValue)]. Possibly indicating that it could be deleted, or the account is not correlated."
+            $auditMessage = "Skipped revoking group: [$($actionContext.PermissionDisplayName)] with groupGuid: [$($actionContext.References.Permission.id)] from account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Reason: No account found where [$($correlationField)] = [$($correlationValue)]. Possibly indicating that it could be deleted, or the account is not correlated."
 
             $outputContext.AuditLogs.Add([PSCustomObject]@{
                     # Action  = "" # Optional

--- a/permissions/products/grantPermission.ps1
+++ b/permissions/products/grantPermission.ps1
@@ -258,19 +258,19 @@ try {
                 }
 
                 if (-Not($actionContext.DryRun -eq $true)) {
-                    Write-Verbose "Requesting product: [$($actionContext.References.Permission.Name)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                    Write-Verbose "Requesting product: [$($actionContext.PermissionDisplayName)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
                     Write-Verbose "Body: $($requestProductSplatParams.Body)"
 
                     $requestedProduct = Invoke-HelloIDRestMethod @requestProductSplatParams
 
                     $outputContext.AuditLogs.Add([PSCustomObject]@{
                             # Action  = "" # Optional
-                            Message = "Granted product: [$($actionContext.References.Permission.Name)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                            Message = "Granted product: [$($actionContext.PermissionDisplayName)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
                             IsError = $false
                         })
                 }
                 else {
-                    Write-Warning "DryRun: Would request product: [$($actionContext.References.Permission.Name)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                    Write-Warning "DryRun: Would request product: [$($actionContext.PermissionDisplayName)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
                     Write-Warning "DryRun: Body: $($requestProductSplatParams.Body)"
                 }
             }
@@ -279,11 +279,11 @@ try {
                 if ($($ex.Exception.GetType().FullName -eq "Microsoft.PowerShell.Commands.HttpResponseException") -or
                     $($ex.Exception.GetType().FullName -eq "System.Net.WebException")) {
                     $errorObj = Resolve-HelloIDError -ErrorObject $ex
-                    $auditMessage = "Error granting product: [$($actionContext.References.Permission.Name)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Error: $($errorObj.FriendlyMessage)"
+                    $auditMessage = "Error granting product: [$($actionContext.PermissionDisplayName)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Error: $($errorObj.FriendlyMessage)"
                     Write-Warning "Error at Line [$($errorObj.ScriptLineNumber)]: $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
                 }
                 else {
-                    $auditMessage = "Error granting product: [$($actionContext.References.Permission.Name)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Error: $($ex.Exception.Message)"
+                    $auditMessage = "Error granting product: [$($actionContext.PermissionDisplayName)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Error: $($ex.Exception.Message)"
                     Write-Warning "Error at Line [$($ex.InvocationInfo.ScriptLineNumber)]: $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
                 }
                 $outputContext.AuditLogs.Add([PSCustomObject]@{

--- a/permissions/products/grantPermission.ps1
+++ b/permissions/products/grantPermission.ps1
@@ -234,6 +234,7 @@ try {
             Uri     = "$($actionContext.Configuration.baseUrl)/product-assignment/by-user/$($correlatedAccount.userGuid)"
             Headers = $headers
             Method  = "GET"
+            UsePaging = $true
         }
 
         $assignments = Invoke-HelloIDRestMethod @assignmentsSplatParams

--- a/permissions/products/grantPermission.ps1
+++ b/permissions/products/grantPermission.ps1
@@ -6,14 +6,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Invoke-HelloIDRestMethod {
     [CmdletBinding()]
@@ -69,7 +61,7 @@ function Invoke-HelloIDRestMethod {
             }
 
             if ($Body) {
-                Write-Verbose "Adding body to request in utf8 byte encoding"
+                Write-Information "Adding body to request in utf8 byte encoding"
                 $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
             }
 
@@ -160,7 +152,7 @@ try {
 
     # Create authorization headers with HelloID API key
     try {
-        Write-Verbose "Creating authorization headers with HelloID API key"
+        Write-Information "Creating authorization headers with HelloID API key"
 
         $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
         $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
@@ -168,7 +160,7 @@ try {
         $key = "Basic $base64"
         $headers = @{"authorization" = $Key }
 
-        Write-Verbose "Created authorization headers with HelloID API key"
+        Write-Information "Created authorization headers with HelloID API key"
     }
     catch {
         $ex = $PSItem
@@ -194,7 +186,7 @@ try {
 
     # Get current account
     try {
-        Write-Verbose "Querying account where [$($correlationField)] = [$($correlationValue)]"
+        Write-Information "Querying account where [$($correlationField)] = [$($correlationValue)]"
         $queryUserSplatParams = @{
             Uri     = "$($actionContext.Configuration.baseUrl)/users/$correlationValue"
             Headers = $headers
@@ -278,8 +270,8 @@ try {
                 }
 
                 if (-Not($actionContext.DryRun -eq $true)) {
-                    Write-Verbose "Requesting product: [$($actionContext.PermissionDisplayName)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
-                    Write-Verbose "Body: $($requestProductSplatParams.Body)"
+                    Write-Information "Requesting product: [$($actionContext.PermissionDisplayName)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                    Write-Information "Body: $($requestProductSplatParams.Body)"
 
                     $requestedProduct = Invoke-HelloIDRestMethod @requestProductSplatParams
 

--- a/permissions/products/import.ps1
+++ b/permissions/products/import.ps1
@@ -203,7 +203,7 @@ try {
 
         $permission = @{
             PermissionReference = @{
-                Reference = $importedProduct.productGuid
+                Id = $importedProduct.productGuid
             }
             DisplayName         = "$($importedProduct.productName)"
             AccountReferences   = $null

--- a/permissions/products/import.ps1
+++ b/permissions/products/import.ps1
@@ -1,0 +1,235 @@
+####################################################################
+# HelloID-Conn-Prov-Target-HelloID-ImportPermissions-Products
+# PowerShell V2
+####################################################################
+
+# Enable TLS1.2
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+
+# Set debug logging
+switch ($actionContext.Configuration.isDebug) {
+    $true { $VerbosePreference = "Continue" }
+    $false { $VerbosePreference = "SilentlyContinue" }
+}
+$InformationPreference = "Continue"
+$WarningPreference = "Continue"
+
+#region functions
+function Invoke-HelloIDRestMethod {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Method,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Uri,
+
+        [object]
+        $Body,
+
+        [string]
+        $ContentType = "application/json",
+
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary]
+        $Headers,
+
+        [Parameter()]
+        [Boolean]
+        $UsePaging = $false,
+
+        [Parameter()]
+        [Int]
+        $Skip = 0,
+
+        [Parameter()]
+        [Int]
+        $Take = 1000,
+
+        [Parameter()]
+        [Int]
+        $TimeoutSec = 60
+    )
+
+    process {
+        try {
+            $splatParams = @{
+                Uri             = $Uri
+                Headers         = $Headers
+                Method          = $Method
+                ContentType     = $ContentType
+                TimeoutSec      = 60
+                UseBasicParsing = $true
+                Verbose         = $false
+                ErrorAction     = "Stop"
+            }
+
+            if ($Body) {
+                Write-Verbose "Adding body to request in utf8 byte encoding"
+                $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
+            }
+
+            if ($UsePaging -eq $true) {
+                $result = [System.Collections.ArrayList]@()
+                $startUri = $splatParams.Uri
+                do {
+                    $splatParams["Uri"] = $startUri + "?take=$($take)&skip=$($skip)"
+                    $response = (Invoke-RestMethod @splatParams)
+                    if ([bool]($response.PSobject.Properties.name -eq "data")) {
+                        $response = $response.data
+                    }
+                    if ($response -is [array]) {
+                        [void]$result.AddRange($response)
+                    }
+                    else {
+                        [void]$result.Add($response)
+                    }
+        
+                    $skip += $take
+                } while (($response | Measure-Object).Count -eq $take)
+            }
+            else {
+                $result = Invoke-RestMethod @splatParams
+            }
+
+            Write-Output $result
+        }
+        catch {
+            throw $_
+        }
+    }
+}
+function Resolve-HelloIDError {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [object]
+        $ErrorObject
+    )
+    process {
+        $httpErrorObj = [PSCustomObject]@{
+            ScriptLineNumber = $ErrorObject.InvocationInfo.ScriptLineNumber
+            Line             = $ErrorObject.InvocationInfo.Line
+            ErrorDetails     = $ErrorObject.Exception.Message
+            FriendlyMessage  = $ErrorObject.Exception.Message
+        }
+        if (-not [string]::IsNullOrEmpty($ErrorObject.ErrorDetails.Message)) {
+            $httpErrorObj.ErrorDetails = $ErrorObject.ErrorDetails.Message
+        }
+        elseif ($ErrorObject.Exception.GetType().FullName -eq 'System.Net.WebException') {
+            if ($null -ne $ErrorObject.Exception.Response) {
+                $streamReaderResponse = [System.IO.StreamReader]::new($ErrorObject.Exception.Response.GetResponseStream()).ReadToEnd()
+                if (-not [string]::IsNullOrEmpty($streamReaderResponse)) {
+                    $httpErrorObj.ErrorDetails = $streamReaderResponse
+                }
+            }
+        }
+        try {
+            $errorDetailsObject = ($httpErrorObj.ErrorDetails | ConvertFrom-Json)
+            # error message can be either in [resultMsg] or [message]
+            if ([bool]($errorDetailsObject.PSobject.Properties.name -eq "resultMsg")) {
+                $httpErrorObj.FriendlyMessage = $errorDetailsObject.resultMsg
+            }
+            elseif ([bool]($errorDetailsObject.PSobject.Properties.name -eq "message")) {
+                $httpErrorObj.FriendlyMessage = $errorDetailsObject.message
+            }
+            $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails # Temporarily assignment
+        }
+        catch {
+            $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails
+            Write-Warning $_.Exception.Message
+        }
+        Write-Output $httpErrorObj
+    }
+}
+#endregion
+
+# Create authorization headers with HelloID API key
+try {
+    Write-Verbose "Creating authorization headers with HelloID API key"
+
+    $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
+    $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
+    $base64 = [System.Convert]::ToBase64String($bytes)
+    $key = "Basic $base64"
+    $headers = @{"authorization" = $Key }
+
+    Write-Verbose "Created authorization headers with HelloID API key"
+}
+catch {
+    $ex = $PSItem
+    if ($($ex.Exception.GetType().FullName -eq "Microsoft.PowerShell.Commands.HttpResponseException") -or
+        $($ex.Exception.GetType().FullName -eq "System.Net.WebException")) {
+        $errorObj = Resolve-HelloIDError -ErrorObject $ex
+        $auditMessage = "Error creating authorization headers with HelloID API key. Error: $($errorObj.FriendlyMessage)"
+        Write-Warning "Error at Line [$($errorObj.ScriptLineNumber)]: $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
+    }
+    else {
+        $auditMessage = "Error creating authorization headers with HelloID API key. Error: $($ex.Exception.Message)"
+        Write-Warning "Error at Line [$($ex.InvocationInfo.ScriptLineNumber)]: $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
+    }
+    $outputContext.AuditLogs.Add([PSCustomObject]@{
+            # Action  = "" # Optional
+            Message = $auditMessage
+            IsError = $true
+        })
+
+    # Throw terminal error
+    throw $auditMessage 
+}
+
+try {
+    Write-Information 'Starting HelloID permission entitlement import'
+
+    $splatImportAssignmentsParams = @{
+        Uri       = "$($actionContext.Configuration.BaseUrl)/product-assignment"
+        Method    = 'GET'
+        Headers   = $headers
+        UsePaging = $true
+    }
+    $importedAssignments = Invoke-HelloIDRestMethod @splatImportAssignmentsParams
+    $assignments = $importedAssignments | Group-Object -Property productGuid -AsHashTable -AsString
+
+    # Group product assignments by productId while joining userGuid to get a list of assigned userGuids per product
+    $products = $importedAssignments | Select-Object -Property productGuid, productName -Unique
+
+    foreach ($importedProduct in $products) {
+        $userGuids = $assignments[$importedProduct.productGuid] | ForEach-Object { $_.userGuid }
+        $userGuids = @($userGuids | Select-Object -Unique)
+
+        $permission = @{
+            PermissionReference = @{
+                Reference = $importedProduct.productGuid
+            }
+            DisplayName         = "$($importedProduct.productName)"
+            AccountReferences   = $null
+        }
+
+        # The code below splits a list of permission members into batches of 100
+        # Each batch is assigned to $permission.AccountReferences and the permission object will be returned to HelloID for each batch
+        # Ensure batching is based on the number of account references to prevent exceeding the maximum limit of 500 account references per batch
+        $batchSize = 500
+        for ($i = 0; $i -lt $userGuids.Count; $i += $batchSize) {
+            $permission.AccountReferences = $userGuids[$i..([Math]::Min($i + $batchSize - 1, $userGuids.Count - 1))]
+            Write-Output $permission
+        }
+    }
+    Write-Information 'HelloID permission entitlement import completed'
+}
+catch {
+    $ex = $PSItem
+    if ($($ex.Exception.GetType().FullName -eq 'Microsoft.PowerShell.Commands.HttpResponseException') -or
+        $($ex.Exception.GetType().FullName -eq 'System.Net.WebException')) {
+        $errorObj = Resolve-HelloIDError -ErrorObject $ex
+        Write-Warning "Error at Line '$($errorObj.ScriptLineNumber)': $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
+        Write-Error "Could not import HelloID permission entitlements. Error: $($errorObj.FriendlyMessage)"
+    }
+    else {
+        Write-Warning "Error at Line '$($ex.InvocationInfo.ScriptLineNumber)': $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
+        Write-Error "Could not import HelloID permission entitlements. Error: $($ex.Exception.Message)"
+    }
+}

--- a/permissions/products/import.ps1
+++ b/permissions/products/import.ps1
@@ -6,14 +6,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Invoke-HelloIDRestMethod {
     [CmdletBinding()]
@@ -69,7 +61,7 @@ function Invoke-HelloIDRestMethod {
             }
 
             if ($Body) {
-                Write-Verbose "Adding body to request in utf8 byte encoding"
+                Write-Information "Adding body to request in utf8 byte encoding"
                 $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
             }
 
@@ -150,7 +142,7 @@ function Resolve-HelloIDError {
 
 # Create authorization headers with HelloID API key
 try {
-    Write-Verbose "Creating authorization headers with HelloID API key"
+    Write-Information "Creating authorization headers with HelloID API key"
 
     $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
     $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
@@ -158,7 +150,7 @@ try {
     $key = "Basic $base64"
     $headers = @{"authorization" = $Key }
 
-    Write-Verbose "Created authorization headers with HelloID API key"
+    Write-Information "Created authorization headers with HelloID API key"
 }
 catch {
     $ex = $PSItem

--- a/permissions/products/permissions.ps1
+++ b/permissions/products/permissions.ps1
@@ -236,8 +236,6 @@ finally {
             DisplayName    = $displayName
             Identification = @{
                 Id   = $product.selfServiceProductGUID
-                Name = $product.name
-                Type = "Product"
             }
         }
 

--- a/permissions/products/permissions.ps1
+++ b/permissions/products/permissions.ps1
@@ -187,16 +187,13 @@ try {
         Write-Verbose 'Querying products'
 
         $queryProductsSplatParams = @{
-            Uri       = "$($actionContext.Configuration.baseUrl)/selfservice/products"
+            Uri       = "$($actionContext.Configuration.baseUrl)/products"
             Headers   = $headers
             Method    = "GET"
             UsePaging = $true
         }
 
         $products = Invoke-HelloIDRestMethod @queryProductsSplatParams
-
-        # Filter for only enabled products
-        $products = $products | Where-Object { $_.isEnabled -eq $true }
 
         Write-Information "Queried products. Result count: $(($products | Measure-Object).Count)"
     }

--- a/permissions/products/permissions.ps1
+++ b/permissions/products/permissions.ps1
@@ -6,14 +6,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Invoke-HelloIDRestMethod {
     [CmdletBinding()]
@@ -69,7 +61,7 @@ function Invoke-HelloIDRestMethod {
             }
 
             if ($Body) {
-                Write-Verbose "Adding body to request in utf8 byte encoding"
+                Write-Information "Adding body to request in utf8 byte encoding"
                 $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
             }
 
@@ -150,7 +142,7 @@ function Resolve-HelloIDError {
 try {
     # Create authorization headers with HelloID API key
     try {
-        Write-Verbose "Creating authorization headers with HelloID API key"
+        Write-Information "Creating authorization headers with HelloID API key"
 
         $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
         $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
@@ -158,7 +150,7 @@ try {
         $key = "Basic $base64"
         $headers = @{"authorization" = $Key }
 
-        Write-Verbose "Created authorization headers with HelloID API key"
+        Write-Information "Created authorization headers with HelloID API key"
     }
     catch {
         $ex = $PSItem
@@ -184,7 +176,7 @@ try {
 
     # Get products
     try {
-        Write-Verbose 'Querying products'
+        Write-Information 'Querying products'
 
         $queryProductsSplatParams = @{
             Uri       = "$($actionContext.Configuration.baseUrl)/products"

--- a/permissions/products/permissions.ps1
+++ b/permissions/products/permissions.ps1
@@ -232,7 +232,7 @@ finally {
         $permission = @{
             DisplayName    = $displayName
             Identification = @{
-                Id   = $product.selfServiceProductGUID
+                Id   = $product.productId
             }
         }
 

--- a/permissions/products/revokePermission.ps1
+++ b/permissions/products/revokePermission.ps1
@@ -6,14 +6,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Invoke-HelloIDRestMethod {
     [CmdletBinding()]
@@ -69,7 +61,7 @@ function Invoke-HelloIDRestMethod {
             }
 
             if ($Body) {
-                Write-Verbose "Adding body to request in utf8 byte encoding"
+                Write-Information "Adding body to request in utf8 byte encoding"
                 $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
             }
 
@@ -160,7 +152,7 @@ try {
 
     # Create authorization headers with HelloID API key
     try {
-        Write-Verbose "Creating authorization headers with HelloID API key"
+        Write-Information "Creating authorization headers with HelloID API key"
 
         $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
         $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
@@ -168,7 +160,7 @@ try {
         $key = "Basic $base64"
         $headers = @{"authorization" = $Key }
 
-        Write-Verbose "Created authorization headers with HelloID API key"
+        Write-Information "Created authorization headers with HelloID API key"
     }
     catch {
         $ex = $PSItem
@@ -194,7 +186,7 @@ try {
 
     # Get current account
     try {
-        Write-Verbose "Querying account where [$($correlationField)] = [$($correlationValue)]"
+        Write-Information "Querying account where [$($correlationField)] = [$($correlationValue)]"
         $queryUserSplatParams = @{
             Uri     = "$($actionContext.Configuration.baseUrl)/users/$correlationValue"
             Headers = $headers
@@ -257,8 +249,8 @@ try {
                 }
 
                 if (-Not($actionContext.DryRun -eq $true)) {
-                    Write-Verbose "Revoking product: [$($actionContext.PermissionDisplayName)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
-                    Write-Verbose "Body: $($revokeProductSplatParams.Body)"
+                    Write-Information "Revoking product: [$($actionContext.PermissionDisplayName)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                    Write-Information "Body: $($revokeProductSplatParams.Body)"
 
                     $revokeProduct = Invoke-HelloIDRestMethod @revokeProductSplatParams
 

--- a/permissions/products/revokePermission.ps1
+++ b/permissions/products/revokePermission.ps1
@@ -1,0 +1,344 @@
+######################################################
+# HelloID-Conn-Prov-Target-HelloID-Revoke-Products
+# PowerShell V2
+######################################################
+
+# Enable TLS1.2
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+
+# Set debug logging
+switch ($actionContext.Configuration.isDebug) {
+    $true { $VerbosePreference = "Continue" }
+    $false { $VerbosePreference = "SilentlyContinue" }
+}
+$InformationPreference = "Continue"
+$WarningPreference = "Continue"
+
+#region functions
+function Invoke-HelloIDRestMethod {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Method,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Uri,
+
+        [object]
+        $Body,
+
+        [string]
+        $ContentType = "application/json",
+
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary]
+        $Headers,
+
+        [Parameter()]
+        [Boolean]
+        $UsePaging = $false,
+
+        [Parameter()]
+        [Int]
+        $Skip = 0,
+
+        [Parameter()]
+        [Int]
+        $Take = 1000,
+
+        [Parameter()]
+        [Int]
+        $TimeoutSec = 60
+    )
+
+    process {
+        try {
+            $splatParams = @{
+                Uri             = $Uri
+                Headers         = $Headers
+                Method          = $Method
+                ContentType     = $ContentType
+                TimeoutSec      = 60
+                UseBasicParsing = $true
+                Verbose         = $false
+                ErrorAction     = "Stop"
+            }
+
+            if ($Body) {
+                Write-Verbose "Adding body to request in utf8 byte encoding"
+                $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
+            }
+
+            if ($UsePaging -eq $true) {
+                $result = [System.Collections.ArrayList]@()
+                $startUri = $splatParams.Uri
+                do {
+                    $splatParams["Uri"] = $startUri + "?take=$($take)&skip=$($skip)"
+                    $response = (Invoke-RestMethod @splatParams)
+                    if ([bool]($response.PSobject.Properties.name -eq "data")) {
+                        $response = $response.data
+                    }
+                    if ($response -is [array]) {
+                        [void]$result.AddRange($response)
+                    }
+                    else {
+                        [void]$result.Add($response)
+                    }
+        
+                    $skip += $take
+                } while (($response | Measure-Object).Count -eq $take)
+            }
+            else {
+                $result = Invoke-RestMethod @splatParams
+            }
+
+            Write-Output $result
+        }
+        catch {
+            throw $_
+        }
+    }
+}
+
+function Resolve-HelloIDError {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [object]
+        $ErrorObject
+    )
+    process {
+        $httpErrorObj = [PSCustomObject]@{
+            ScriptLineNumber = $ErrorObject.InvocationInfo.ScriptLineNumber
+            Line             = $ErrorObject.InvocationInfo.Line
+            ErrorDetails     = $ErrorObject.Exception.Message
+            FriendlyMessage  = $ErrorObject.Exception.Message
+        }
+        if (-not [string]::IsNullOrEmpty($ErrorObject.ErrorDetails.Message)) {
+            $httpErrorObj.ErrorDetails = $ErrorObject.ErrorDetails.Message
+        }
+        elseif ($ErrorObject.Exception.GetType().FullName -eq "System.Net.WebException") {
+            if ($null -ne $ErrorObject.Exception.Response) {
+                $streamReaderResponse = [System.IO.StreamReader]::new($ErrorObject.Exception.Response.GetResponseStream()).ReadToEnd()
+                if (-not [string]::IsNullOrEmpty($streamReaderResponse)) {
+                    $httpErrorObj.ErrorDetails = $streamReaderResponse
+                }
+            }
+        }
+        try {
+            $errorDetailsObject = ($httpErrorObj.ErrorDetails | ConvertFrom-Json)
+            # error message can be either in [resultMsg] or [message]
+            if ([bool]($errorDetailsObject.PSobject.Properties.name -eq "resultMsg")) {
+                $httpErrorObj.FriendlyMessage = $errorDetailsObject.resultMsg
+            }
+            elseif ([bool]($errorDetailsObject.PSobject.Properties.name -eq "message")) {
+                $httpErrorObj.FriendlyMessage = $errorDetailsObject.message
+            }
+        }
+        catch {
+            $httpErrorObj.FriendlyMessage = $httpErrorObj.ErrorDetails
+        }
+        Write-Output $httpErrorObj
+    }
+}
+#endregion functions
+
+#region Correlation mapping
+$correlationField = "userGUID"
+$correlationValue = $actionContext.References.Account
+#endregion Correlation mapping
+
+try {
+    # Verify if [aRef] has a value
+    if ([string]::IsNullOrEmpty($($actionContext.References.Account))) {
+        throw "The account reference could not be found"
+    }
+
+    # Create authorization headers with HelloID API key
+    try {
+        Write-Verbose "Creating authorization headers with HelloID API key"
+
+        $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
+        $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
+        $base64 = [System.Convert]::ToBase64String($bytes)
+        $key = "Basic $base64"
+        $headers = @{"authorization" = $Key }
+
+        Write-Verbose "Created authorization headers with HelloID API key"
+    }
+    catch {
+        $ex = $PSItem
+        if ($($ex.Exception.GetType().FullName -eq "Microsoft.PowerShell.Commands.HttpResponseException") -or
+            $($ex.Exception.GetType().FullName -eq "System.Net.WebException")) {
+            $errorObj = Resolve-HelloIDError -ErrorObject $ex
+            $auditMessage = "Error creating authorization headers with HelloID API key. Error: $($errorObj.FriendlyMessage)"
+            Write-Warning "Error at Line [$($errorObj.ScriptLineNumber)]: $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
+        }
+        else {
+            $auditMessage = "Error creating authorization headers with HelloID API key. Error: $($ex.Exception.Message)"
+            Write-Warning "Error at Line [$($ex.InvocationInfo.ScriptLineNumber)]: $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
+        }
+        $outputContext.AuditLogs.Add([PSCustomObject]@{
+                # Action  = "" # Optional
+                Message = $auditMessage
+                IsError = $true
+            })
+
+        # Throw terminal error
+        throw $auditMessage   
+    }
+
+    # Get current account
+    try {
+        Write-Verbose "Querying account where [$($correlationField)] = [$($correlationValue)]"
+        $queryUserSplatParams = @{
+            Uri     = "$($actionContext.Configuration.baseUrl)/users/$correlationValue"
+            Headers = $headers
+            Method  = "GET"
+        }
+
+        $correlatedAccount = Invoke-HelloIDRestMethod @queryUserSplatParams
+    }
+    catch {
+        $ex = $PSItem
+        if ($($ex.Exception.GetType().FullName -eq "Microsoft.PowerShell.Commands.HttpResponseException") -or
+            $($ex.Exception.GetType().FullName -eq "System.Net.WebException")) {
+            $errorObj = Resolve-HelloIDError -ErrorObject $ex
+
+            $auditMessage = "Error querying account where [$($correlationField)] = [$($correlationValue)]. Error: $($errorObj.FriendlyMessage)"
+            Write-Warning "Error at Line [$($errorObj.ScriptLineNumber)]: $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
+        }
+        else {
+            $auditMessage = "Error querying account where [$($correlationField)] = [$($correlationValue)]. Error: $($ex.Exception.Message)"
+            Write-Warning "Error at Line [$($ex.InvocationInfo.ScriptLineNumber)]: $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
+        }
+
+        $outputContext.AuditLogs.Add([PSCustomObject]@{
+                # Action  = "" # Optional
+                Message = $auditMessage
+                IsError = $true
+            })
+
+        # Throw terminal error
+        throw $auditMessage
+    }
+
+    if (($correlatedAccount | Measure-Object).count -eq 1) {
+        $action = "RevokePermission"
+    }
+    elseif (($correlatedAccount | Measure-Object).count -gt 1) {
+        $action = "MultipleFound"
+    }
+    elseif (($correlatedAccount | Measure-Object).count -eq 0) {
+        $action = "NotFound"
+    }
+
+    # Process
+    switch ($action) {
+        "RevokePermission" {
+            # Revoke product
+            try {
+                $permissionBody = @{
+                    productGUID     = $actionContext.References.Permission.Id
+                    userGUID        = $correlatedAccount.userGuid
+                    executeActions  = $true
+                }
+
+                $body = ($permissionBody | ConvertTo-Json -Depth 10)
+                $revokeProductSplatParams = @{
+                    Uri     = "$($actionContext.Configuration.baseUrl)/product-assignment/unassign/by-product"
+                    Headers = $headers
+                    Method  = "POST"
+                    Body    = $body
+                }
+
+                if (-Not($actionContext.DryRun -eq $true)) {
+                    Write-Verbose "Revoking product: [$($actionContext.PermissionDisplayName)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                    Write-Verbose "Body: $($revokeProductSplatParams.Body)"
+
+                    $revokeProduct = Invoke-HelloIDRestMethod @revokeProductSplatParams
+
+                    $outputContext.AuditLogs.Add([PSCustomObject]@{
+                            # Action  = "" # Optional
+                            Message = "Revoked product: [$($actionContext.PermissionDisplayName)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                            IsError = $false
+                        })
+                }
+                else {
+                    Write-Warning "DryRun: Would revoke product: [$($actionContext.PermissionDisplayName)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json)."
+                    Write-Warning "DryRun: Body: $($revokeProductSplatParams.Body)"
+                }
+            }
+            catch {
+                $ex = $PSItem
+                if ($($ex.Exception.GetType().FullName -eq "Microsoft.PowerShell.Commands.HttpResponseException") -or
+                    $($ex.Exception.GetType().FullName -eq "System.Net.WebException")) {
+                    $errorObj = Resolve-HelloIDError -ErrorObject $ex
+                    $auditMessage = "Error revoking product: [$($actionContext.PermissionDisplayName)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Error: $($errorObj.FriendlyMessage)"
+                    Write-Warning "Error at Line [$($errorObj.ScriptLineNumber)]: $($errorObj.Line). Error: $($errorObj.ErrorDetails)"
+                }
+                else {
+                    $auditMessage = "Error revoking product: [$($actionContext.PermissionDisplayName)] with selfServiceProductGUID: [$($actionContext.References.Permission.id)] for account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Error: $($ex.Exception.Message)"
+                    Write-Warning "Error at Line [$($ex.InvocationInfo.ScriptLineNumber)]: $($ex.InvocationInfo.Line). Error: $($ex.Exception.Message)"
+                }
+                $outputContext.AuditLogs.Add([PSCustomObject]@{
+                        # Action  = "" # Optional
+                        Message = $auditMessage
+                        IsError = $true
+                    })
+
+                # Throw terminal error
+                throw $auditMessage
+            }
+
+            break
+        }
+
+        "MultipleFound" {
+            $auditMessage = "Multiple accounts found where [$($correlationField)] = [$($correlationValue)]. Please correct this so the accounts are unique."
+
+            $outputContext.AuditLogs.Add([PSCustomObject]@{
+                    # Action  = "" # Optional
+                    Message = $auditMessage
+                    IsError = $true
+                })
+        
+            # Throw terminal error
+            throw $auditMessage
+
+            break
+        }
+
+        "NotFound" {
+            $auditMessage = "No account found where [$($correlationField)] = [$($correlationValue)]. Possibly indicating that it could be deleted, or the account is not correlated."
+
+            $outputContext.AuditLogs.Add([PSCustomObject]@{
+                    # Action  = "" # Optional
+                    Message = $auditMessage
+                    IsError = $true
+                })
+        
+            # Throw terminal error
+            throw $auditMessage
+
+            break
+        }
+    }
+}
+catch {
+    $ex = $PSItem
+    Write-Warning "Terminal error occurred. Error Message: $($ex.Exception.Message)"
+}
+finally {
+    # Check if auditLogs contains errors, if no errors are found, set success to true
+    if ($outputContext.AuditLogs.IsError -contains $true) {
+        $outputContext.Success = $false
+    }
+    else {
+        $outputContext.Success = $true
+    }
+}

--- a/update.ps1
+++ b/update.ps1
@@ -6,14 +6,6 @@
 # Enable TLS1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 
-# Set debug logging
-switch ($actionContext.Configuration.isDebug) {
-    $true { $VerbosePreference = "Continue" }
-    $false { $VerbosePreference = "SilentlyContinue" }
-}
-$InformationPreference = "Continue"
-$WarningPreference = "Continue"
-
 #region functions
 function Invoke-HelloIDRestMethod {
     [CmdletBinding()]
@@ -69,7 +61,7 @@ function Invoke-HelloIDRestMethod {
             }
 
             if ($Body) {
-                Write-Verbose "Adding body to request in utf8 byte encoding"
+                Write-Information "Adding body to request in utf8 byte encoding"
                 $splatParams["Body"] = ([System.Text.Encoding]::UTF8.GetBytes($Body))
             }
 
@@ -188,7 +180,7 @@ try {
 
     # Create authorization headers with HelloID API key
     try {
-        Write-Verbose "Creating authorization headers with HelloID API key"
+        Write-Information "Creating authorization headers with HelloID API key"
 
         $pair = "$($actionContext.Configuration.apiKey):$($actionContext.Configuration.apiSecret)"
         $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
@@ -196,7 +188,7 @@ try {
         $key = "Basic $base64"
         $headers = @{"authorization" = $Key }
 
-        Write-Verbose "Created authorization headers with HelloID API key"
+        Write-Information "Created authorization headers with HelloID API key"
     }
     catch {
         $ex = $PSItem
@@ -222,7 +214,7 @@ try {
 
     # Get current account
     try {
-        Write-Verbose "Querying account where [$($correlationField)] = [$($correlationValue)]"
+        Write-Information "Querying account where [$($correlationField)] = [$($correlationValue)]"
         $queryUserSplatParams = @{
             Uri     = "$($actionContext.Configuration.baseUrl)/users/$correlationValue"
             Headers = $headers
@@ -329,8 +321,8 @@ try {
                 }
 
                 if (-Not($actionContext.DryRun -eq $true)) {
-                    Write-Verbose "Updating account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Account property(s) updated: [$($propertiesChanged.name -join ',')]"
-                    Write-Verbose "Body: $($updateUserSplatParams.Body)"
+                    Write-Information "Updating account with AccountReference: $($actionContext.References.Account | ConvertTo-Json). Account property(s) updated: [$($propertiesChanged.name -join ',')]"
+                    Write-Information "Body: $($updateUserSplatParams.Body)"
 
                     $updatedAccount = Invoke-HelloIDRestMethod @updateUserSplatParams
                     $outputContext.Data = $updatedAccount


### PR DESCRIPTION
**Feature: Removed pref name**
Removed the usage of the permission name as reference.
Replaced `actionContext.References.Permission.Name` with `actionContext.PermissionDisplayName`

**Feature: Check for Already Granted Product Permissions**
Added a check to prevent duplicate product permission grants if already assigned.
Issue: https://github.com/Tools4everBV/HelloID-Conn-Prov-Target-HelloID/issues/9

**Feature: Added `revokePermission` Script**
Introduced a new script to manage and revoke product permissions.
Issue: https://github.com/Tools4everBV/HelloID-Conn-Prov-Target-HelloID/issues/7

**Documentation Update**
Updated `README.md` to include additional API endpoints.
Clarified product grant/revoke functionality.

**Feature: Add import scripts**
Introduced 4 scripts for account and (sub)-permission imports.

**Feature: Add password property**
Added the password property to `outputContext.Data` so it can be used in notifications.
Issue: https://github.com/Tools4everBV/HelloID-Conn-Prov-Target-HelloID/issues/6

**Bugfix: Failure in Compare-Object**
Prevent `ReferenceObject `and `DifferenceObject `becoming null causing `update`, `enable `and `disable `script to fail.
Issue: https://github.com/Tools4everBV/HelloID-Conn-Prov-Target-HelloID/issues/10

**Other improvements**
* Reused `Get-ADSanitizedGroupName` function in `subPermissions.ps1` and `resources.ps1`
* Replaced deprecated GET API `/selfservice/products` with `/products`
* `enable`, `update` and `disable` scripts:
-- Made sure `$outputContext.PreviousData` is not altered with `$actionContext.Data` due to shallow cloning in combination with a nested `userAttributes` object
-- Improve account update logic to simplify property comparison and logging
* Field mapping: only store `userGUID` in account data and remove update action for `userGUID`